### PR TITLE
Migrate relex subcrates to their own regex crate

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/rust/.devcontainer/base.Dockerfile
+
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/rust
+{
+	"name": "Rust",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+			// Use bullseye when on local on arm64/Apple Silicon.
+			"VARIANT": "bullseye"
+		}
+	},
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined"
+	],
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		},
+		"rust-analyzer.checkOnSave.command": "clippy"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"vadimcn.vscode-lldb",
+		"mutantdino.resourcemonitor",
+		"matklad.rust-analyzer",
+		"tamasfe.even-better-toml",
+		"serayuzgur.crates"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+# Introduction
+
+# Linked Issues
+
+# Dependencies
+
+# Test
+- [ ] Tested Locally
+- [ ] Documented
+
+# Review
+- [ ] Ready for review
+- [ ] Ready to merge
+
+# Deployment

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,36 @@
+
+name: Bench
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  build_and_test:
+    name: Bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: measure benchmarks on main
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+      - uses: actions/checkout@v2
+        with:
+          clean: false
+      - name: measure benchmarks on branch
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+      - name: upload benchmark report
+        uses: actions/upload-artifact@v1
+        with:
+          name: Benchmark report
+          path: target/criterion/

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -17,13 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
-      - name: measure benchmarks on main
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
-      - uses: actions/checkout@v2
-        with:
           clean: false
       - name: measure benchmarks on branch
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+name: Test
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+  unit_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["compiler", "runtime"]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "regex-compiler"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+workspace = ".."
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "linear_scaling_of_input"
+path = "benches/linear.rs"
+harness = false
+
+[dependencies]
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.1" }
+regex-runtime = { path = "../runtime/" }

--- a/compiler/benches/linear.rs
+++ b/compiler/benches/linear.rs
@@ -1,0 +1,44 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use regex_compiler::*;
+
+fn pad_input_to_length_with(prefix: &str, suffix: &str, pad_str: &str, len: usize) -> String {
+    let prefix_len = prefix.chars().count();
+    let suffix_len = suffix.chars().count();
+    let req_padding = len - suffix_len;
+
+    if suffix_len > len || prefix_len > len || (suffix_len + prefix_len) > len {
+        "".to_string()
+    } else {
+        prefix
+            .chars()
+            .chain(pad_str.chars().cycle().take(req_padding))
+            .chain(suffix.chars())
+            .collect()
+    }
+}
+
+pub fn exponential_input_size_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pattern length compilation comparison");
+    let pad = "ab";
+
+    (1..10)
+        .map(|exponent| 2usize.pow(exponent))
+        .map(|input_len| (pad_input_to_length_with("^", "", pad, input_len), input_len))
+        .map(|(input, len)| (input.chars().enumerate().collect::<Vec<_>>(), len))
+        .for_each(|(input, sample_size)| {
+            group.throughput(Throughput::Elements(sample_size as u64));
+            group.bench_with_input(
+                BenchmarkId::new("pattern input length of size", sample_size),
+                &input,
+                |b, input| {
+                    b.iter(|| {
+                        let res = parse(input).map(compile);
+                        assert!(res.is_ok())
+                    })
+                },
+            );
+        })
+}
+
+criterion_group!(benches, exponential_input_size_comparison);
+criterion_main!(benches);

--- a/compiler/examples/re/main.rs
+++ b/compiler/examples/re/main.rs
@@ -1,0 +1,54 @@
+use std::io::{self, BufRead};
+
+use regex_compiler::{compile, parse};
+
+const USAGE: &str = "grep-analog PATTERN [FILE]";
+
+fn main() -> Result<(), String> {
+    let (debug, args) = std::env::args()
+        .skip(1)
+        .fold((false, vec![]), |(debug, mut args), arg| {
+            if arg == "--debug" || arg == "-d" {
+                (true, args)
+            } else {
+                args.push(arg);
+                (debug, args)
+            }
+        });
+    let arg_len = args.len();
+
+    let (pattern, input) = match arg_len {
+        1 => args
+            .get(0)
+            .map(|pattern| (pattern, io::stdin()))
+            .ok_or_else(|| USAGE.to_string()),
+        _ => Err(USAGE.to_string()),
+    }?;
+
+    let pattern_input: Vec<(usize, char)> = pattern.chars().enumerate().collect();
+    let program = parse(&pattern_input)
+        .map_err(|e| format!("{:?}", e))
+        .and_then(compile)?;
+
+    if debug {
+        println!(
+            "DEBUG
+--------
+{}--------
+",
+            program
+        )
+    }
+
+    for line in input.lock().lines() {
+        match line {
+            Ok(line) => match regex_runtime::run::<0>(&program, &line) {
+                Some(_) => println!("{}", line),
+                None => continue,
+            },
+            Err(e) => return Err(format!("{}", e)),
+        }
+    }
+
+    Ok(())
+}

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -1,0 +1,552 @@
+#[derive(Debug, PartialEq)]
+pub enum Regex {
+    StartOfStringAnchored(Expression),
+    Unanchored(Expression),
+}
+
+// Expression
+
+#[derive(Debug, PartialEq)]
+pub struct Expression(pub Vec<SubExpression>);
+
+#[derive(Debug, PartialEq)]
+pub struct SubExpression(pub Vec<SubExpressionItem>);
+
+impl From<SubExpressionItem> for SubExpression {
+    fn from(src: SubExpressionItem) -> Self {
+        Self(vec![src])
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SubExpressionItem {
+    Match(Match),
+    Group(Group),
+    Anchor(Anchor),
+    Backreference(Integer),
+}
+
+pub trait IsSubExpressionItem: Into<SubExpressionItem> {}
+
+impl From<Match> for SubExpressionItem {
+    fn from(src: Match) -> Self {
+        Self::Match(src)
+    }
+}
+
+impl From<Group> for SubExpressionItem {
+    fn from(src: Group) -> Self {
+        Self::Group(src)
+    }
+}
+
+impl From<Anchor> for SubExpressionItem {
+    fn from(src: Anchor) -> Self {
+        Self::Anchor(src)
+    }
+}
+
+impl From<Backreference> for SubExpressionItem {
+    fn from(src: Backreference) -> Self {
+        Self::Backreference(src.0)
+    }
+}
+
+// Group
+#[derive(Debug, PartialEq)]
+pub enum Group {
+    Capturing {
+        expression: Expression,
+    },
+    CapturingWithQuantifier {
+        expression: Expression,
+        quantifier: Quantifier,
+    },
+    NonCapturing {
+        expression: Expression,
+    },
+    NonCapturingWithQuantifier {
+        expression: Expression,
+        quantifier: Quantifier,
+    },
+}
+
+impl IsSubExpressionItem for Group {}
+
+pub struct GroupNonCapturingModifier;
+
+// Matchers
+
+#[derive(Debug, PartialEq)]
+pub enum Match {
+    WithQuantifier {
+        item: MatchItem,
+        quantifier: Quantifier,
+    },
+    WithoutQuantifier {
+        item: MatchItem,
+    },
+}
+
+impl IsSubExpressionItem for Match {}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, PartialEq)]
+pub enum MatchItem {
+    MatchAnyCharacter,
+    MatchCharacterClass(MatchCharacterClass),
+    MatchCharacter(MatchCharacter),
+}
+
+pub trait IsMatchItem: Into<MatchItem> {}
+
+impl From<MatchAnyCharacter> for MatchItem {
+    fn from(_: MatchAnyCharacter) -> Self {
+        Self::MatchAnyCharacter
+    }
+}
+
+impl From<MatchCharacterClass> for MatchItem {
+    fn from(src: MatchCharacterClass) -> Self {
+        Self::MatchCharacterClass(src)
+    }
+}
+
+impl From<MatchCharacter> for MatchItem {
+    fn from(src: MatchCharacter) -> Self {
+        Self::MatchCharacter(src)
+    }
+}
+
+pub struct MatchAnyCharacter;
+impl IsMatchItem for MatchAnyCharacter {}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, PartialEq)]
+pub enum MatchCharacterClass {
+    CharacterGroup(CharacterGroup),
+    CharacterClass(CharacterClass),
+    CharacterClassFromUnicodeCategory(CharacterClassFromUnicodeCategory),
+}
+
+impl IsMatchItem for MatchCharacterClass {}
+
+pub trait IsMatchCharacterClass: Into<MatchCharacterClass> {}
+
+impl From<CharacterGroup> for MatchCharacterClass {
+    fn from(src: CharacterGroup) -> Self {
+        Self::CharacterGroup(src)
+    }
+}
+
+impl From<CharacterClass> for MatchCharacterClass {
+    fn from(src: CharacterClass) -> Self {
+        Self::CharacterClass(src)
+    }
+}
+
+impl From<CharacterClassFromUnicodeCategory> for MatchCharacterClass {
+    fn from(src: CharacterClassFromUnicodeCategory) -> Self {
+        Self::CharacterClassFromUnicodeCategory(src)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MatchCharacter(pub Char);
+impl IsMatchItem for MatchCharacter {}
+
+// Character Classes
+
+#[derive(Debug, PartialEq)]
+pub enum CharacterGroup {
+    NegatedItems(Vec<CharacterGroupItem>),
+    Items(Vec<CharacterGroupItem>),
+}
+
+impl IsMatchCharacterClass for CharacterGroup {}
+
+pub struct CharacterGroupNegativeModifier;
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, PartialEq)]
+pub enum CharacterGroupItem {
+    CharacterClass(CharacterClass),
+    CharacterClassFromUnicodeCategory(UnicodeCategoryName),
+    CharacterRange(Char, Char),
+    Char(Char),
+}
+
+pub trait IsCharacterGroupItem: Into<CharacterGroupItem> {}
+
+impl From<CharacterClass> for CharacterGroupItem {
+    fn from(src: CharacterClass) -> Self {
+        Self::CharacterClass(src)
+    }
+}
+
+impl From<CharacterClassFromUnicodeCategory> for CharacterGroupItem {
+    fn from(src: CharacterClassFromUnicodeCategory) -> Self {
+        Self::CharacterClassFromUnicodeCategory(src.0)
+    }
+}
+
+impl From<CharacterRange> for CharacterGroupItem {
+    fn from(src: CharacterRange) -> Self {
+        let CharacterRange {
+            lower_bound,
+            upper_bound,
+        } = src;
+
+        Self::CharacterRange(lower_bound, upper_bound)
+    }
+}
+
+impl From<Char> for CharacterGroupItem {
+    fn from(src: Char) -> Self {
+        Self::Char(src)
+    }
+}
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, PartialEq)]
+pub enum CharacterClass {
+    AnyWord,
+    AnyWordInverted,
+    AnyDecimalDigit,
+    AnyDecimalDigitInverted,
+}
+
+impl IsMatchCharacterClass for CharacterClass {}
+impl IsCharacterGroupItem for CharacterClass {}
+
+pub trait IsCharacterClass: Into<CharacterClass> {}
+
+impl From<CharacterClassAnyWord> for CharacterClass {
+    fn from(_: CharacterClassAnyWord) -> Self {
+        Self::AnyWord
+    }
+}
+
+impl From<CharacterClassAnyWordInverted> for CharacterClass {
+    fn from(_: CharacterClassAnyWordInverted) -> Self {
+        Self::AnyWordInverted
+    }
+}
+
+impl From<CharacterClassAnyDecimalDigit> for CharacterClass {
+    fn from(_: CharacterClassAnyDecimalDigit) -> Self {
+        Self::AnyDecimalDigit
+    }
+}
+
+impl From<CharacterClassAnyDecimalDigitInverted> for CharacterClass {
+    fn from(_: CharacterClassAnyDecimalDigitInverted) -> Self {
+        Self::AnyDecimalDigitInverted
+    }
+}
+
+pub struct CharacterClassAnyWord;
+impl IsCharacterClass for CharacterClassAnyWord {}
+
+pub struct CharacterClassAnyWordInverted;
+impl IsCharacterClass for CharacterClassAnyWordInverted {}
+
+pub struct CharacterClassAnyDecimalDigit;
+impl IsCharacterClass for CharacterClassAnyDecimalDigit {}
+
+pub struct CharacterClassAnyDecimalDigitInverted;
+impl IsCharacterClass for CharacterClassAnyDecimalDigitInverted {}
+
+#[derive(Debug, PartialEq)]
+pub struct CharacterClassFromUnicodeCategory(pub UnicodeCategoryName);
+impl IsMatchCharacterClass for CharacterClassFromUnicodeCategory {}
+impl IsCharacterGroupItem for CharacterClassFromUnicodeCategory {}
+
+#[derive(Debug, PartialEq)]
+pub struct UnicodeCategoryName(pub Letters);
+
+pub struct CharacterRange {
+    lower_bound: Char,
+    upper_bound: Char,
+}
+
+impl CharacterRange {
+    pub fn new(lower_bound: Char, upper_bound: Char) -> Self {
+        Self {
+            lower_bound,
+            upper_bound,
+        }
+    }
+}
+
+impl IsCharacterGroupItem for CharacterRange {}
+
+// Quantifiers
+
+#[derive(Debug, PartialEq)]
+pub enum Quantifier {
+    Eager(QuantifierType),
+    Lazy(QuantifierType),
+}
+
+/// Signifies that a type is representative of a Regex Quantifier and can be
+/// converted to a `QualifierType` variant.
+pub trait IsQuantifierType: Into<QuantifierType> {}
+
+/// Represents all variants of quantifier types
+#[derive(Debug, PartialEq)]
+pub enum QuantifierType {
+    MatchExactRange(Integer),
+    MatchAtLeastRange(Integer),
+    MatchBetweenRange {
+        lower_bound: Integer,
+        upper_bound: Integer,
+    },
+    /// Represents a quantifier representing a match of zero or more of the
+    /// preceeding field. Represented by the `*` quantifier.
+    ZeroOrMore,
+    /// Represents a quantifier representing a match of one or more of the
+    /// preceeding field. Represented by the `+` quantifier.
+    OneOrMore,
+    /// Represents an optional quantifier representing a match of zero or one
+    /// field. Represented by the `?` quantifier.
+    ZeroOrOne,
+}
+
+impl From<ZeroOrMoreQuantifier> for QuantifierType {
+    fn from(_: ZeroOrMoreQuantifier) -> Self {
+        QuantifierType::ZeroOrMore
+    }
+}
+
+impl From<OneOrMoreQuantifier> for QuantifierType {
+    fn from(_: OneOrMoreQuantifier) -> Self {
+        QuantifierType::OneOrMore
+    }
+}
+
+impl From<ZeroOrOneQuantifier> for QuantifierType {
+    fn from(_: ZeroOrOneQuantifier) -> Self {
+        QuantifierType::ZeroOrOne
+    }
+}
+
+impl From<RangeQuantifier> for QuantifierType {
+    fn from(src: RangeQuantifier) -> Self {
+        let lower_bound = src.lower_bound;
+        let upper_bound = src.upper_bound;
+
+        match (lower_bound, upper_bound) {
+            (lower, None) => QuantifierType::MatchExactRange(lower.0),
+            (lower, Some(None)) => QuantifierType::MatchAtLeastRange(lower.0),
+            (lower, Some(Some(upper))) => QuantifierType::MatchBetweenRange {
+                lower_bound: lower.0,
+                upper_bound: upper.0,
+            },
+        }
+    }
+}
+
+/// Represents an optional modifier for the quantifier represented by the `?`
+/// quantifier.
+pub struct LazyModifier;
+
+/// A Regex Range Qualifier representable by the following three expressions.
+/// `{n}`: Match exactly.
+/// `{n,}`: Match at least.
+/// `{n,m}` Match between range.
+pub struct RangeQuantifier {
+    lower_bound: RangeQuantifierLowerBound,
+    upper_bound: Option<Option<RangeQuantifierUpperBound>>,
+}
+
+impl RangeQuantifier {
+    pub fn new(
+        lower_bound: RangeQuantifierLowerBound,
+        upper_bound: Option<Option<RangeQuantifierUpperBound>>,
+    ) -> Self {
+        Self {
+            lower_bound,
+            upper_bound,
+        }
+    }
+}
+
+impl IsQuantifierType for RangeQuantifier {}
+
+/// A lower-bound representation of a range qualifier.
+/// `{n,m}` representing the `n` in the previous expression.
+pub struct RangeQuantifierLowerBound(pub Integer);
+
+/// An upper-bound representation of a range qualifier.
+/// `{n,m}` representing the `m` in the previous expression.
+pub struct RangeQuantifierUpperBound(pub Integer);
+
+/// Represents a quantifier representing a match of zero or more of the
+/// preceeding field. Represented by the `*` quantifier.
+pub struct ZeroOrMoreQuantifier;
+
+impl IsQuantifierType for ZeroOrMoreQuantifier {}
+
+/// Represents a quantifier representing a match of one or more of the
+/// preceeding field. Represented by the `+` quantifier.
+pub struct OneOrMoreQuantifier;
+
+impl IsQuantifierType for OneOrMoreQuantifier {}
+
+/// Represents an optional quantifier representing a match of zero or one
+/// field. Represented by the `?` quantifier.
+pub struct ZeroOrOneQuantifier;
+
+impl IsQuantifierType for ZeroOrOneQuantifier {}
+
+// Backreference
+
+pub struct Backreference(pub Integer);
+impl IsSubExpressionItem for Backreference {}
+
+// Anchors
+
+pub struct StartOfStringAnchor;
+
+pub trait IsAnchor: Into<Anchor> {}
+
+#[derive(Debug, PartialEq)]
+pub enum Anchor {
+    WordBoundary,
+    NonWordBoundary,
+    StartOfStringOnly,
+    EndOfStringOnlyNonNewline,
+    EndOfStringOnly,
+    PreviousMatchEnd,
+    EndOfString,
+}
+
+impl IsSubExpressionItem for Anchor {}
+
+impl From<AnchorWordBoundary> for Anchor {
+    fn from(_: AnchorWordBoundary) -> Self {
+        Self::WordBoundary
+    }
+}
+
+impl From<AnchorNonWordBoundary> for Anchor {
+    fn from(_: AnchorNonWordBoundary) -> Self {
+        Self::NonWordBoundary
+    }
+}
+
+impl From<AnchorStartOfStringOnly> for Anchor {
+    fn from(_: AnchorStartOfStringOnly) -> Self {
+        Self::StartOfStringOnly
+    }
+}
+
+impl From<AnchorEndOfStringOnlyNotNewline> for Anchor {
+    fn from(_: AnchorEndOfStringOnlyNotNewline) -> Self {
+        Self::EndOfStringOnlyNonNewline
+    }
+}
+
+impl From<AnchorEndOfStringOnly> for Anchor {
+    fn from(_: AnchorEndOfStringOnly) -> Self {
+        Self::EndOfStringOnly
+    }
+}
+
+impl From<AnchorPreviousMatchEnd> for Anchor {
+    fn from(_: AnchorPreviousMatchEnd) -> Self {
+        Self::PreviousMatchEnd
+    }
+}
+
+impl From<AnchorEndOfString> for Anchor {
+    fn from(_: AnchorEndOfString) -> Self {
+        Self::EndOfString
+    }
+}
+
+/// An anchor representing by "\b".
+pub struct AnchorWordBoundary;
+impl IsAnchor for AnchorWordBoundary {}
+
+/// An anchor representing by "\B".
+pub struct AnchorNonWordBoundary;
+impl IsAnchor for AnchorNonWordBoundary {}
+
+/// An anchor representing by "\A".
+pub struct AnchorStartOfStringOnly;
+impl IsAnchor for AnchorStartOfStringOnly {}
+
+/// An anchor representing by "\z".
+pub struct AnchorEndOfStringOnlyNotNewline;
+impl IsAnchor for AnchorEndOfStringOnlyNotNewline {}
+
+/// An anchor representing by "\Z".
+pub struct AnchorEndOfStringOnly;
+impl IsAnchor for AnchorEndOfStringOnly {}
+
+/// An anchor representing by "\G".
+pub struct AnchorPreviousMatchEnd;
+impl IsAnchor for AnchorPreviousMatchEnd {}
+
+/// An anchor representing by "$".
+pub struct AnchorEndOfString;
+impl IsAnchor for AnchorEndOfString {}
+
+// Terminals
+
+#[derive(Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Integer(pub isize);
+
+impl Integer {
+    pub fn as_isize(&self) -> isize {
+        self.0
+    }
+}
+
+impl From<Integer> for isize {
+    fn from(src: Integer) -> Self {
+        src.as_isize()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Letters(pub Vec<char>);
+
+impl Letters {
+    pub fn as_char_slice(&self) -> &[char] {
+        &self.0
+    }
+}
+
+impl AsRef<[char]> for Letters {
+    fn as_ref(&self) -> &[char] {
+        self.as_char_slice()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Char(pub char);
+impl IsCharacterGroupItem for Char {}
+
+impl Char {
+    pub fn as_char(&self) -> char {
+        self.0
+    }
+}
+
+impl AsRef<char> for Char {
+    fn as_ref(&self) -> &char {
+        &self.0
+    }
+}
+
+impl From<Char> for char {
+    fn from(src: Char) -> char {
+        src.as_char()
+    }
+}

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -1,0 +1,1838 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::ast;
+use regex_runtime::*;
+
+/// Tracks an incrementing identifier for save groups.
+static SAVE_GROUP_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// A internal representation of the `regex_runtime::Opcode` type, with relative
+/// addressing.
+///
+/// ## Note
+/// This type is meant to exist only internally and should be
+/// refined to the `regex_runtime::Opcode type
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
+enum RelativeOpcode {
+    Any,
+    Consume(char),
+    ConsumeSet(CharacterSet),
+    Split(i32, i32),
+    Jmp(i32),
+    StartSave(usize),
+    EndSave(usize),
+    Match,
+}
+
+impl RelativeOpcode {
+    fn into_opcode_with_index(self, sets: &mut Vec<CharacterSet>, idx: u32) -> Option<Opcode> {
+        match self {
+            RelativeOpcode::Any => Some(Opcode::Any),
+            RelativeOpcode::Consume(c) => Some(Opcode::Consume(InstConsume::new(c))),
+            RelativeOpcode::Split(rel_x, rel_y) => {
+                let signed_idx = idx as i32;
+                let x: u32 = (signed_idx + rel_x).try_into().ok()?;
+                let y: u32 = (signed_idx + rel_y).try_into().ok()?;
+
+                Some(Opcode::Split(InstSplit::new(
+                    InstIndex::from(x),
+                    InstIndex::from(y),
+                )))
+            }
+            RelativeOpcode::Jmp(rel_jmp_to) => {
+                let signed_idx = idx as i32;
+                let jmp_to: u32 = (signed_idx + rel_jmp_to).try_into().ok()?;
+
+                Some(Opcode::Jmp(InstJmp::new(InstIndex::from(jmp_to))))
+            }
+            RelativeOpcode::StartSave(slot) => Some(Opcode::StartSave(InstStartSave::new(slot))),
+            RelativeOpcode::EndSave(slot) => Some(Opcode::EndSave(InstEndSave::new(slot))),
+            RelativeOpcode::Match => Some(Opcode::Match),
+            RelativeOpcode::ConsumeSet(char_set) => {
+                let found = sets.iter().position(|set| set == &char_set);
+                let set_idx = match found {
+                    Some(set_idx) => set_idx,
+                    None => {
+                        let set_idx = sets.len();
+                        sets.push(char_set);
+                        set_idx
+                    }
+                };
+
+                Some(Opcode::ConsumeSet(InstConsumeSet { idx: set_idx }))
+            }
+        }
+    }
+
+    fn into_opcode_with_index_unchecked(self, sets: &mut Vec<CharacterSet>, idx: u32) -> Opcode {
+        self.into_opcode_with_index(sets, idx).unwrap()
+    }
+}
+
+type RelativeOpcodes = Vec<RelativeOpcode>;
+
+pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
+    let suffix = [RelativeOpcode::Match];
+
+    let relative_ops: Result<RelativeOpcodes, _> = match regex_ast {
+        ast::Regex::StartOfStringAnchored(expr) => {
+            expression(expr).map(|expr| expr.into_iter().chain(suffix.into_iter()).collect())
+        }
+        ast::Regex::Unanchored(expr) => expression(expr).map(|expr| {
+            // match anything
+            let prefix = [
+                RelativeOpcode::Split(3, 1),
+                RelativeOpcode::Any,
+                RelativeOpcode::Jmp(-2),
+            ];
+
+            prefix
+                .into_iter()
+                .chain(expr.into_iter())
+                .chain(suffix.into_iter())
+                .collect()
+        }),
+    };
+
+    relative_ops
+        .map(|rel_ops| {
+            let (sets, absolute_insts) = rel_ops
+                .into_iter()
+                .enumerate()
+                // truncate idx to a u32
+                .map(|(idx, sets)| (idx as u32, sets))
+                .fold((vec![], vec![]), |(mut sets, mut insts), (idx, opcode)| {
+                    let absolute_opcode = opcode.into_opcode_with_index_unchecked(&mut sets, idx);
+                    insts.push(absolute_opcode);
+
+                    (sets, insts)
+                });
+
+            (sets, absolute_insts)
+        })
+        .map(|(sets, insts)| Instructions::new(sets, insts))
+}
+
+fn expression(expr: ast::Expression) -> Result<RelativeOpcodes, String> {
+    let ast::Expression(subexprs) = expr;
+
+    let compiled_subexprs = subexprs
+        .into_iter()
+        .map(subexpression)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    alternations_for_supplied_relative_opcodes(compiled_subexprs)
+}
+
+fn subexpression(subexpr: ast::SubExpression) -> Result<RelativeOpcodes, String> {
+    let ast::SubExpression(items) = subexpr;
+
+    items
+        .into_iter()
+        .map(|subexpr_item| match subexpr_item {
+            ast::SubExpressionItem::Match(m) => match_item(m),
+            ast::SubExpressionItem::Group(g) => group(g),
+            ast::SubExpressionItem::Anchor(_) => todo!(),
+            ast::SubExpressionItem::Backreference(_) => unimplemented!(),
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|opcodes| opcodes.into_iter().flatten().collect())
+}
+
+macro_rules! generate_range_quantifier_block {
+    (eager, $min:expr, $consumer:expr) => {
+        $consumer
+            .clone()
+            .into_iter()
+            .cycle()
+            .take($consumer.len() * $min as usize)
+            .into_iter()
+            // jump past end of expression
+            .chain(vec![RelativeOpcode::Split(1, (($consumer.len() + 2) as i32))].into_iter())
+            .chain($consumer.clone().into_iter())
+            // return to split
+            .chain(vec![RelativeOpcode::Jmp(-($consumer.len() as i32) - 1)].into_iter())
+            .collect()
+    };
+
+    (lazy, $min:expr, $consumer:expr) => {
+        $consumer
+            .clone()
+            .into_iter()
+            .cycle()
+            .take($consumer.len() * $min as usize)
+            .into_iter()
+            // jump past end of expression
+            .chain(vec![RelativeOpcode::Split((($consumer.len() + 2) as i32), 1)].into_iter())
+            .chain($consumer.clone().into_iter())
+            // return to split
+            .chain(vec![RelativeOpcode::Jmp(-($consumer.len() as i32) - 1)].into_iter())
+            .collect()
+    };
+
+    (eager, $min:expr, $max:expr, $consumer:expr) => {
+        $consumer
+            .clone()
+            .into_iter()
+            .cycle()
+            .take($consumer.len() * $min as usize)
+            .into_iter()
+            .chain((0..($max - $min)).flat_map(|_| {
+                vec![RelativeOpcode::Split(1, ($consumer.len() as i32) + 1)]
+                    .into_iter()
+                    .chain($consumer.clone().into_iter())
+            }))
+            .collect()
+    };
+
+    (lazy, $min:expr, $max:expr, $consumer:expr) => {
+        $consumer
+            .clone()
+            .into_iter()
+            .cycle()
+            .take($consumer.len() * $min as usize)
+            .into_iter()
+            .chain((0..($max - $min)).flat_map(|_| {
+                vec![RelativeOpcode::Split(($consumer.len() as i32) + 1, 1)]
+                    .into_iter()
+                    .chain($consumer.clone().into_iter())
+            }))
+            .collect()
+    };
+}
+
+fn match_item(m: ast::Match) -> Result<RelativeOpcodes, String> {
+    use ast::{
+        Char, Integer, Match, MatchCharacter, MatchCharacterClass, MatchItem, Quantifier,
+        QuantifierType,
+    };
+
+    match m {
+        // Any character matchers
+        Match::WithoutQuantifier {
+            item: MatchItem::MatchAnyCharacter,
+        } => Ok(vec![RelativeOpcode::Any]),
+        Match::WithQuantifier {
+            item: MatchItem::MatchAnyCharacter,
+            quantifier,
+        } => {
+            match quantifier {
+                Quantifier::Eager(QuantifierType::ZeroOrOne) => Ok(
+                    generate_range_quantifier_block!(eager, 0, 1, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Lazy(QuantifierType::ZeroOrOne) => Ok(
+                    generate_range_quantifier_block!(lazy, 0, 1, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Eager(QuantifierType::ZeroOrMore) => Ok(
+                    generate_range_quantifier_block!(eager, 0, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Lazy(QuantifierType::ZeroOrMore) => Ok(
+                    generate_range_quantifier_block!(lazy, 0, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Eager(QuantifierType::OneOrMore) => Ok(
+                    generate_range_quantifier_block!(eager, 1, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Lazy(QuantifierType::OneOrMore) => Ok(
+                    generate_range_quantifier_block!(lazy, 1, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+                | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                    Ok(vec![RelativeOpcode::Any; cnt as usize])
+                }
+                Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(cnt))) => Ok(
+                    generate_range_quantifier_block!(eager, cnt, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(cnt))) => Ok(
+                    generate_range_quantifier_block!(lazy, cnt, vec![RelativeOpcode::Any]),
+                ),
+                Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(lower),
+                    upper_bound: Integer(upper),
+                }) => Ok(generate_range_quantifier_block!(
+                    eager,
+                    lower,
+                    upper,
+                    vec![RelativeOpcode::Any]
+                )),
+                Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(lower),
+                    upper_bound: Integer(upper),
+                }) => Ok(generate_range_quantifier_block!(
+                    lazy,
+                    lower,
+                    upper,
+                    vec![RelativeOpcode::Any]
+                )),
+            }
+        }
+
+        // Character matchers
+        Match::WithoutQuantifier {
+            item: MatchItem::MatchCharacter(MatchCharacter(Char(c))),
+        } => Ok(vec![RelativeOpcode::Consume(c)]),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacter(MatchCharacter(Char(c))),
+            quantifier,
+        } => {
+            match quantifier {
+                Quantifier::Eager(QuantifierType::ZeroOrOne) => Ok(
+                    generate_range_quantifier_block!(eager, 0, 1, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Lazy(QuantifierType::ZeroOrOne) => Ok(
+                    generate_range_quantifier_block!(lazy, 0, 1, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Eager(QuantifierType::ZeroOrMore) => Ok(
+                    generate_range_quantifier_block!(eager, 0, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Lazy(QuantifierType::ZeroOrMore) => Ok(
+                    generate_range_quantifier_block!(lazy, 0, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Eager(QuantifierType::OneOrMore) => Ok(
+                    generate_range_quantifier_block!(eager, 1, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Lazy(QuantifierType::OneOrMore) => Ok(
+                    generate_range_quantifier_block!(lazy, 1, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+                | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                    Ok(vec![RelativeOpcode::Consume(c); cnt as usize])
+                }
+                Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(cnt))) => Ok(
+                    generate_range_quantifier_block!(eager, cnt, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(cnt))) => Ok(
+                    generate_range_quantifier_block!(lazy, cnt, vec![RelativeOpcode::Consume(c)]),
+                ),
+                Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(lower),
+                    upper_bound: Integer(upper),
+                }) => Ok(generate_range_quantifier_block!(
+                    eager,
+                    lower,
+                    upper,
+                    vec![RelativeOpcode::Consume(c)]
+                )),
+                Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(lower),
+                    upper_bound: Integer(upper),
+                }) => Ok(generate_range_quantifier_block!(
+                    lazy,
+                    lower,
+                    upper,
+                    vec![RelativeOpcode::Consume(c)]
+                )),
+            }
+        }
+
+        // Character classes
+        Match::WithoutQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+        } => character_class(cc),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(cc)),
+            quantifier,
+        } => match quantifier {
+            Quantifier::Eager(QuantifierType::ZeroOrOne) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, 0, 1, rel_ops)),
+            Quantifier::Lazy(QuantifierType::ZeroOrOne) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, 0, 1, rel_ops)),
+            Quantifier::Eager(QuantifierType::ZeroOrMore) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, 0, rel_ops)),
+            Quantifier::Lazy(QuantifierType::ZeroOrMore) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, 0, rel_ops)),
+            Quantifier::Eager(QuantifierType::OneOrMore) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, 1, rel_ops)),
+            Quantifier::Lazy(QuantifierType::OneOrMore) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, 1, rel_ops)),
+            Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+            | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                character_class(cc).map(|rel_ops| {
+                    let multiple_of_len = rel_ops.len() * (cnt as usize);
+
+                    rel_ops.into_iter().cycle().take(multiple_of_len).collect()
+                })
+            }
+            Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                character_class(cc)
+                    .map(|rel_ops| generate_range_quantifier_block!(eager, lower, rel_ops))
+            }
+            Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                character_class(cc)
+                    .map(|rel_ops| generate_range_quantifier_block!(lazy, lower, rel_ops))
+            }
+            Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                lower_bound: Integer(lower),
+                upper_bound: Integer(upper),
+            }) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, lower, upper, rel_ops)),
+            Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                lower_bound: Integer(lower),
+                upper_bound: Integer(upper),
+            }) => character_class(cc)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, lower, upper, rel_ops)),
+        },
+
+        // Character groups
+        Match::WithoutQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(cg)),
+        } => character_group(cg),
+        Match::WithQuantifier {
+            item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(cg)),
+            quantifier,
+        } => match quantifier {
+            Quantifier::Eager(QuantifierType::ZeroOrOne) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, 0, 1, rel_ops)),
+            Quantifier::Lazy(QuantifierType::ZeroOrOne) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, 0, 1, rel_ops)),
+            Quantifier::Eager(QuantifierType::ZeroOrMore) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, 0, rel_ops)),
+            Quantifier::Lazy(QuantifierType::ZeroOrMore) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, 0, rel_ops)),
+            Quantifier::Eager(QuantifierType::OneOrMore) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, 1, rel_ops)),
+            Quantifier::Lazy(QuantifierType::OneOrMore) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, 1, rel_ops)),
+            Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+            | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                character_group(cg).map(|rel_ops| {
+                    let multiple_of_len = rel_ops.len() * (cnt as usize);
+
+                    rel_ops.into_iter().cycle().take(multiple_of_len).collect()
+                })
+            }
+            Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                character_group(cg)
+                    .map(|rel_ops| generate_range_quantifier_block!(eager, lower, rel_ops))
+            }
+            Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                character_group(cg)
+                    .map(|rel_ops| generate_range_quantifier_block!(lazy, lower, rel_ops))
+            }
+            Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                lower_bound: Integer(lower),
+                upper_bound: Integer(upper),
+            }) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(eager, lower, upper, rel_ops)),
+            Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                lower_bound: Integer(lower),
+                upper_bound: Integer(upper),
+            }) => character_group(cg)
+                .map(|rel_ops| generate_range_quantifier_block!(lazy, lower, upper, rel_ops)),
+        },
+
+        // Unicode categories
+        Match::WithQuantifier {
+            item:
+                MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClassFromUnicodeCategory(
+                    _,
+                )),
+            quantifier: _,
+        } => unimplemented!(),
+        Match::WithoutQuantifier {
+            item:
+                MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClassFromUnicodeCategory(
+                    _,
+                )),
+        } => unimplemented!(),
+    }
+}
+
+fn character_group(cg: ast::CharacterGroup) -> Result<RelativeOpcodes, String> {
+    let sets: Vec<RelativeOpcodes> = match cg {
+        ast::CharacterGroup::NegatedItems(cgis) => cgis
+            .into_iter()
+            .map(character_group_item_to_set)
+            .map(|set| set.invert_membership())
+            .map(|set| vec![RelativeOpcode::ConsumeSet(set)])
+            .collect(),
+
+        ast::CharacterGroup::Items(cgis) => cgis
+            .into_iter()
+            .map(character_group_item_to_set)
+            .map(|set| vec![RelativeOpcode::ConsumeSet(set)])
+            .collect(),
+    };
+
+    alternations_for_supplied_relative_opcodes(sets)
+}
+
+fn character_group_item_to_set(cgi: ast::CharacterGroupItem) -> CharacterSet {
+    use ast::Char;
+
+    match cgi {
+        ast::CharacterGroupItem::CharacterClassFromUnicodeCategory(_) => unimplemented!(),
+        ast::CharacterGroupItem::CharacterClass(cc) => character_class_to_set(cc),
+        ast::CharacterGroupItem::CharacterRange(Char(lower), Char(upper)) => {
+            let alphabet = CharacterAlphabet::Range(lower..=upper);
+            CharacterSet::inclusive(alphabet)
+        }
+        ast::CharacterGroupItem::Char(Char(c)) => {
+            CharacterSet::inclusive(CharacterAlphabet::Explicit(vec![c]))
+        }
+    }
+}
+
+// character classes
+
+/// A representation of a AnyWordClass character class, in character set format.
+pub struct AnyWordClass;
+
+impl AnyWordClass {
+    const RANGES: [std::ops::RangeInclusive<char>; 4] =
+        ['a'..='z', 'A'..='Z', '0'..='9', '_'..='_'];
+}
+
+impl CharacterSetRepresentable for AnyWordClass {}
+
+impl From<AnyWordClass> for CharacterSet {
+    fn from(_: AnyWordClass) -> Self {
+        CharacterSet::inclusive(CharacterAlphabet::Ranges(AnyWordClass::RANGES.to_vec()))
+    }
+}
+
+/// A representation of a AnyWordClassInverted character class, in character
+/// set format.
+pub struct AnyWordClassInverted;
+
+impl CharacterSetRepresentable for AnyWordClassInverted {}
+
+impl From<AnyWordClassInverted> for CharacterSet {
+    fn from(_: AnyWordClassInverted) -> Self {
+        CharacterSet::exclusive(CharacterAlphabet::Ranges(AnyWordClass::RANGES.to_vec()))
+    }
+}
+
+/// A representation of a AnyDecimalDigitClass character class, in character
+/// set format.
+pub struct AnyDecimalDigitClass;
+
+impl AnyDecimalDigitClass {
+    const RANGE: std::ops::RangeInclusive<char> = '0'..='9';
+}
+
+impl CharacterSetRepresentable for AnyDecimalDigitClass {}
+
+impl From<AnyDecimalDigitClass> for CharacterSet {
+    fn from(_: AnyDecimalDigitClass) -> Self {
+        CharacterSet::inclusive(CharacterAlphabet::Range(AnyDecimalDigitClass::RANGE))
+    }
+}
+
+/// A representation of a AnyDecimalDigitClassInverted character class, in
+/// character set format.
+pub struct AnyDecimalDigitClassInverted;
+
+impl CharacterSetRepresentable for AnyDecimalDigitClassInverted {}
+
+impl From<AnyDecimalDigitClassInverted> for CharacterSet {
+    fn from(_: AnyDecimalDigitClassInverted) -> Self {
+        CharacterSet::exclusive(CharacterAlphabet::Range(AnyDecimalDigitClass::RANGE))
+    }
+}
+
+fn character_class(cc: ast::CharacterClass) -> Result<RelativeOpcodes, String> {
+    let set = character_class_to_set(cc);
+
+    Ok(vec![RelativeOpcode::ConsumeSet(set)])
+}
+
+fn character_class_to_set(cc: ast::CharacterClass) -> CharacterSet {
+    match cc {
+        ast::CharacterClass::AnyWord => AnyWordClass.into(),
+        ast::CharacterClass::AnyWordInverted => AnyWordClassInverted.into(),
+
+        ast::CharacterClass::AnyDecimalDigit => AnyDecimalDigitClass.into(),
+        ast::CharacterClass::AnyDecimalDigitInverted => AnyDecimalDigitClassInverted.into(),
+    }
+}
+
+/// Generates alternations from a block of relative operations.
+fn alternations_for_supplied_relative_opcodes(
+    rel_ops: Vec<RelativeOpcodes>,
+) -> Result<RelativeOpcodes, String> {
+    let subexpr_cnt = rel_ops.len();
+
+    let length_of_rel_ops: Vec<_> = rel_ops
+        .iter()
+        .enumerate()
+        .map(|(idx, subexpr)| ((idx + 1 == subexpr_cnt), subexpr))
+        .map(|(is_last, subexpr)| {
+            // last alternation doesn't require a split prefix and jump suffix
+            if is_last {
+                subexpr.len()
+            } else {
+                subexpr.len() + 2
+            }
+        })
+        .collect();
+
+    let total_length_of_compiled_expr: usize = length_of_rel_ops.iter().sum();
+    let start_end_offsets_by_subexpr: Vec<(usize, usize)> = length_of_rel_ops
+        .iter()
+        .fold(
+            // add 1 to set end at first instruction of next expr
+            (total_length_of_compiled_expr + 1, vec![]),
+            |(offset_to_end, mut acc), &subexpr_len| {
+                let new_offset_to_end = offset_to_end - subexpr_len;
+
+                acc.push((subexpr_len, new_offset_to_end));
+                (new_offset_to_end, acc)
+            },
+        )
+        .1;
+
+    let compiled_ops_with_applied_alternations = rel_ops
+        .into_iter()
+        .zip(start_end_offsets_by_subexpr.into_iter())
+        .enumerate()
+        .map(|(idx, (opcodes, (start, end)))| (idx as u32, opcodes, (start as i32, end as i32)))
+        .map(|(idx, opcodes, start_end_offsets)| {
+            let optional_next_offsets =
+                ((idx + 1) != subexpr_cnt as u32).then(|| start_end_offsets);
+            (optional_next_offsets, opcodes)
+        })
+        .flat_map(|(start_of_next, ops)| match start_of_next {
+            Some((start_of_next_subexpr_offset, end_of_expr_offset)) => {
+                [RelativeOpcode::Split(1, start_of_next_subexpr_offset)]
+                    .into_iter()
+                    .chain(ops.into_iter())
+                    .chain([RelativeOpcode::Jmp(end_of_expr_offset)].into_iter())
+                    .collect()
+            }
+            None => ops,
+        })
+        .collect();
+
+    Ok(compiled_ops_with_applied_alternations)
+}
+
+// Groups
+
+fn group(g: ast::Group) -> Result<RelativeOpcodes, String> {
+    use ast::{Integer, Quantifier, QuantifierType};
+
+    match g {
+        ast::Group::Capturing { expression: expr } => {
+            let save_group_id = SAVE_GROUP_ID.fetch_add(1, Ordering::SeqCst);
+            let save_group_prefix = [RelativeOpcode::StartSave(save_group_id)];
+            let save_group_suffix = [RelativeOpcode::EndSave(save_group_id)];
+
+            expression(expr).map(|insts| {
+                save_group_prefix
+                    .into_iter()
+                    .chain(insts.into_iter())
+                    .chain(save_group_suffix.into_iter())
+                    .collect()
+            })
+        }
+        ast::Group::CapturingWithQuantifier {
+            expression: expr,
+            quantifier,
+        } => {
+            let save_group_id = SAVE_GROUP_ID.fetch_add(1, Ordering::SeqCst);
+            let save_group_prefix = [RelativeOpcode::StartSave(save_group_id)];
+            let save_group_suffix = [RelativeOpcode::EndSave(save_group_id)];
+
+            expression(expr)
+                .map(|rel_ops| match quantifier {
+                    Quantifier::Eager(QuantifierType::ZeroOrOne) => {
+                        generate_range_quantifier_block!(eager, 0, 1, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::ZeroOrOne) => {
+                        generate_range_quantifier_block!(lazy, 0, 1, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::ZeroOrMore) => {
+                        generate_range_quantifier_block!(eager, 0, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::ZeroOrMore) => {
+                        generate_range_quantifier_block!(lazy, 0, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::OneOrMore) => {
+                        generate_range_quantifier_block!(eager, 1, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::OneOrMore) => {
+                        generate_range_quantifier_block!(lazy, 1, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                        generate_range_quantifier_block!(eager, lower, rel_ops)
+                    }
+                    Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                        generate_range_quantifier_block!(lazy, lower, rel_ops)
+                    }
+                    Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                        lower_bound: Integer(lower),
+                        upper_bound: Integer(upper),
+                    }) => generate_range_quantifier_block!(eager, lower, upper, rel_ops),
+                    Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                        lower_bound: Integer(lower),
+                        upper_bound: Integer(upper),
+                    }) => generate_range_quantifier_block!(lazy, lower, upper, rel_ops),
+                    Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+                    | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                        let multiple_of_len = rel_ops.len() * (cnt as usize);
+
+                        rel_ops.into_iter().cycle().take(multiple_of_len).collect()
+                    }
+                })
+                .map(|insts: RelativeOpcodes| {
+                    save_group_prefix
+                        .into_iter()
+                        .chain(insts.into_iter())
+                        .chain(save_group_suffix.into_iter())
+                        .collect()
+                })
+        }
+
+        ast::Group::NonCapturing { expression: expr } => expression(expr),
+        ast::Group::NonCapturingWithQuantifier {
+            expression: expr,
+            quantifier,
+        } => expression(expr).map(|rel_ops| match quantifier {
+            Quantifier::Eager(QuantifierType::ZeroOrOne) => {
+                generate_range_quantifier_block!(eager, 0, 1, rel_ops)
+            }
+            Quantifier::Lazy(QuantifierType::ZeroOrOne) => {
+                generate_range_quantifier_block!(lazy, 0, 1, rel_ops)
+            }
+            Quantifier::Eager(QuantifierType::ZeroOrMore) => {
+                generate_range_quantifier_block!(eager, 0, rel_ops)
+            }
+            Quantifier::Lazy(QuantifierType::ZeroOrMore) => {
+                generate_range_quantifier_block!(lazy, 0, rel_ops)
+            }
+            Quantifier::Eager(QuantifierType::OneOrMore) => {
+                generate_range_quantifier_block!(eager, 1, rel_ops)
+            }
+            Quantifier::Lazy(QuantifierType::OneOrMore) => {
+                generate_range_quantifier_block!(lazy, 1, rel_ops)
+            }
+            Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                generate_range_quantifier_block!(eager, lower, rel_ops)
+            }
+            Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(lower))) => {
+                generate_range_quantifier_block!(lazy, lower, rel_ops)
+            }
+            Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                lower_bound: Integer(lower),
+                upper_bound: Integer(upper),
+            }) => generate_range_quantifier_block!(eager, lower, upper, rel_ops),
+            Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                lower_bound: Integer(lower),
+                upper_bound: Integer(upper),
+            }) => generate_range_quantifier_block!(lazy, lower, upper, rel_ops),
+            Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(cnt)))
+            | Quantifier::Eager(QuantifierType::MatchExactRange(Integer(cnt))) => {
+                let multiple_of_len = rel_ops.len() * (cnt as usize);
+
+                rel_ops.into_iter().cycle().take(multiple_of_len).collect()
+            }
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ast::*;
+
+    #[test]
+    fn should_compile_unanchored_character_match() {
+        // approximate to `ab`
+        let regex_ast = Regex::Unanchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+            }),
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('b')),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_anchored_character_match() {
+        // approximate to `^ab`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+            }),
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('b')),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_alternation() {
+        // approximate to `^a|b`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![
+            SubExpression(vec![SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+            })]),
+            SubExpression(vec![SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+            })]),
+        ]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(4))),
+                Opcode::Consume(InstConsume::new('b')),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_any_character_match() {
+        // approximate to `.`
+        let regex_ast = Regex::Unanchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::Any,
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_zero_or_more_quantified_item() {
+        // approximate to `^.*`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+                quantifier: Quantifier::Eager(QuantifierType::ZeroOrMore),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^a*`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                quantifier: Quantifier::Eager(QuantifierType::ZeroOrMore),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_one_or_more_quantified_item() {
+        // approximate to `^.+`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+                quantifier: Quantifier::Eager(QuantifierType::OneOrMore),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Any,
+                Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^a+`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                quantifier: Quantifier::Eager(QuantifierType::OneOrMore),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_match_zero_or_one_item() {
+        // approximate to `^.?`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+                quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(2))),
+                Opcode::Any,
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^a?`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(2))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_exact_match_quantified_item() {
+        // approximate to `^.{2}`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+                quantifier: Quantifier::Eager(QuantifierType::MatchExactRange(Integer(2))),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_opcodes(vec![Opcode::Any, Opcode::Any, Opcode::Match,])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^a{2}`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                quantifier: Quantifier::Eager(QuantifierType::MatchExactRange(Integer(2))),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Match,
+            ])),
+            compile(regex_ast)
+        )
+    }
+
+    #[test]
+    fn should_compile_match_at_least_quantified_item() {
+        // approximate to `^.{2,}`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+                quantifier: Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(2))),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Any,
+                Opcode::Any,
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^a{2,}`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                quantifier: Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(2))),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_match_between_quantified_item() {
+        // approximate to `^.{2,4}`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchAnyCharacter,
+                quantifier: Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Any,
+                Opcode::Any,
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(4))),
+                Opcode::Any,
+                Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(6))),
+                Opcode::Any,
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^a{2,4}`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithQuantifier {
+                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                quantifier: Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(4))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(6))),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_character_classes() {
+        // approximate to `^\w`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                    CharacterClass::AnyWord,
+                )),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Ranges(
+                    vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_',]
+                ))])
+                .with_opcodes(vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ])),
+            compile(regex_ast)
+        );
+
+        // approximate to `^\d`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                    CharacterClass::AnyDecimalDigit,
+                )),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                    '0'..='9'
+                ))])
+                .with_opcodes(vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_character_classes_with_quantifiers() {
+        let quantifier_and_expected_opcodes = vec![
+            // approximate to `^\d?`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(2))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d*`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d+`
+            (
+                Quantifier::Eager(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^\d+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+        ];
+
+        for (id, (quantifier, expected_opcodes)) in
+            quantifier_and_expected_opcodes.into_iter().enumerate()
+        {
+            let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Match(Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyDecimalDigit,
+                    )),
+                    quantifier,
+                }),
+            ])]));
+
+            let res = compile(regex_ast);
+            assert_eq!(
+                (
+                    id,
+                    Ok(Instructions::default()
+                        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                            '0'..='9'
+                        ))])
+                        .with_opcodes(expected_opcodes))
+                ),
+                (id, res)
+            );
+        }
+    }
+
+    #[test]
+    fn should_compile_single_character_character_group() {
+        // approximate to `^[a]`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(
+                    CharacterGroup::Items(vec![CharacterGroupItem::Char(Char('a'))]),
+                )),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Explicit(
+                    vec!['a']
+                ))])
+                .with_opcodes(vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match
+                ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_compound_character_group() {
+        // approximate to `^[az]`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(
+                    CharacterGroup::Items(vec![
+                        CharacterGroupItem::Char(Char('a')),
+                        CharacterGroupItem::Char(Char('z')),
+                    ]),
+                )),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_sets(vec![
+                    CharacterSet::inclusive(CharacterAlphabet::Explicit(vec!['a'],)),
+                    CharacterSet::inclusive(CharacterAlphabet::Explicit(vec!['z'],))
+                ])
+                .with_opcodes(vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(4))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(1)),
+                    Opcode::Match,
+                ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_character_group_range() {
+        // approximate to `^[0-9]`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Match(Match::WithoutQuantifier {
+                item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(
+                    CharacterGroup::Items(vec![CharacterGroupItem::CharacterRange(
+                        Char('0'),
+                        Char('9'),
+                    )]),
+                )),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                    '0'..='9'
+                )),])
+                .with_opcodes(vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_character_groups_with_quantifiers() {
+        let quantifier_and_expected_opcodes = vec![
+            // approximate to `^[0-9]?`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(2))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]*`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]+`
+            (
+                Quantifier::Eager(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^[0-9]+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
+                    Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+        ];
+
+        for (id, (quantifier, expected_opcodes)) in
+            quantifier_and_expected_opcodes.into_iter().enumerate()
+        {
+            let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Match(Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterGroup(
+                        CharacterGroup::Items(vec![CharacterGroupItem::CharacterRange(
+                            Char('0'),
+                            Char('9'),
+                        )]),
+                    )),
+                    quantifier,
+                }),
+            ])]));
+
+            let res = compile(regex_ast);
+            assert_eq!(
+                (
+                    id,
+                    Ok(Instructions::default()
+                        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                            '0'..='9'
+                        ))])
+                        .with_opcodes(expected_opcodes))
+                ),
+                (id, res)
+            );
+        }
+    }
+
+    #[test]
+    fn should_compile_capturing_group() {
+        // reset save group id.
+        SAVE_GROUP_ID.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        // approximate to `^(a)(b)`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Group(Group::Capturing {
+                expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
+                    Match::WithoutQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                    },
+                )])]),
+            }),
+            SubExpressionItem::Group(Group::Capturing {
+                expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
+                    Match::WithoutQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+                    },
+                )])]),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::StartSave(InstStartSave::new(1)),
+                Opcode::Consume(InstConsume::new('b')),
+                Opcode::EndSave(InstEndSave::new(1)),
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_nested_capturing_group() {
+        // reset save group id.
+        SAVE_GROUP_ID.store(0, std::sync::atomic::Ordering::SeqCst);
+
+        // approximate to `^(a(b))`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Group(Group::Capturing {
+                expression: Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Match(Match::WithoutQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                    }),
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+                            }),
+                        ])]),
+                    }),
+                ])]),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default().with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::StartSave(InstStartSave::new(1)),
+                Opcode::Consume(InstConsume::new('b')),
+                Opcode::EndSave(InstEndSave::new(1)),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match
+            ])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_non_capturing_group() {
+        // approximate to `^(?:a)`
+        let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+            SubExpressionItem::Group(Group::NonCapturing {
+                expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
+                    Match::WithoutQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                    },
+                )])]),
+            }),
+        ])]));
+
+        assert_eq!(
+            Ok(Instructions::default()
+                .with_opcodes(vec![Opcode::Consume(InstConsume::new('a')), Opcode::Match])),
+            compile(regex_ast)
+        );
+    }
+
+    #[test]
+    fn should_compile_quantified_capturing_group() {
+        let quantifier_and_expected_opcodes = vec![
+            // approximate to `^(a)?`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(2))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)*`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)+`
+            (
+                Quantifier::Eager(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a)+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2}`
+            (
+                Quantifier::Eager(QuantifierType::MatchExactRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,}`
+            (
+                Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(6))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(2))),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,4}`
+            (
+                Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(5))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(7))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(a){2,4}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+                vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(7), InstIndex::from(6))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ],
+            ),
+        ];
+
+        for (id, (quantifier, expected_opcodes)) in
+            quantifier_and_expected_opcodes.into_iter().enumerate()
+        {
+            // reset the save group id.
+            SAVE_GROUP_ID.store(0, std::sync::atomic::Ordering::SeqCst);
+
+            let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Group(Group::Capturing {
+                    expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
+                        Match::WithQuantifier {
+                            item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            quantifier,
+                        },
+                    )])]),
+                }),
+            ])]));
+
+            let res = compile(regex_ast);
+            assert_eq!(
+                (
+                    id,
+                    Ok(Instructions::default().with_opcodes(expected_opcodes))
+                ),
+                (id, res)
+            );
+        }
+    }
+
+    #[test]
+    fn should_compile_quantified_non_capturing_group() {
+        let quantifier_and_expected_opcodes = vec![
+            // approximate to `^(?:a)?`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(2))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a)??`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrOne),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(1))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a)*`
+            (
+                Quantifier::Eager(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(1), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a)*?`
+            (
+                Quantifier::Lazy(QuantifierType::ZeroOrMore),
+                vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a)+`
+            (
+                Quantifier::Eager(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a)+?`
+            (
+                Quantifier::Lazy(QuantifierType::OneOrMore),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(2))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(1))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a){2}`
+            (
+                Quantifier::Eager(QuantifierType::MatchExactRange(Integer(2))),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a){2}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchExactRange(Integer(2))),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a){2,}`
+            (
+                Quantifier::Eager(QuantifierType::MatchAtLeastRange(Integer(2))),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a){2,}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchAtLeastRange(Integer(2))),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a){2,4}`
+            (
+                Quantifier::Eager(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(4))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(6))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Match,
+                ],
+            ),
+            // approximate to `^(?:a){2,4}?`
+            (
+                Quantifier::Lazy(QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                }),
+                vec![
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(3))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(5))),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Match,
+                ],
+            ),
+        ];
+
+        for (id, (quantifier, expected_opcodes)) in
+            quantifier_and_expected_opcodes.into_iter().enumerate()
+        {
+            let regex_ast = Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Group(Group::NonCapturing {
+                    expression: Expression(vec![SubExpression(vec![SubExpressionItem::Match(
+                        Match::WithQuantifier {
+                            item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            quantifier,
+                        },
+                    )])]),
+                }),
+            ])]));
+
+            let res = compile(regex_ast);
+            assert_eq!(
+                (
+                    id,
+                    Ok(Instructions::default().with_opcodes(expected_opcodes))
+                ),
+                (id, res)
+            );
+        }
+    }
+}

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod ast;
+pub mod compiler;
+pub mod parser;
+
+pub use compiler::compile;
+pub use parser::{parse, ParseErr};

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -1,0 +1,990 @@
+use parcel::parsers::character::{alphabetic, digit, expect_character};
+use parcel::prelude::v1::*;
+
+use super::ast;
+
+#[derive(PartialEq)]
+pub enum ParseErr {
+    InvalidRegex,
+    Undefined(String),
+}
+
+impl std::fmt::Debug for ParseErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undefined(err) => write!(f, "undefined parse error: {}", err),
+            Self::InvalidRegex => write!(f, "provided regex is invalid",),
+        }
+    }
+}
+
+pub fn parse(input: &[(usize, char)]) -> Result<ast::Regex, ParseErr> {
+    regex()
+        .parse(input)
+        .map_err(|err| ParseErr::Undefined(format!("unspecified parse error occured: {}", err)))
+        .and_then(|ms| match ms {
+            MatchStatus::Match { inner, .. } => Ok(inner),
+            MatchStatus::NoMatch(..) => Err(ParseErr::InvalidRegex),
+        })
+}
+
+fn regex<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Regex> {
+    parcel::join(
+        parcel::optional(start_of_string_anchor()).map(|anchored| anchored.is_some()),
+        expression(),
+    )
+    .map(|(anchored, expression)| match anchored {
+        true => ast::Regex::StartOfStringAnchored(expression),
+        false => ast::Regex::Unanchored(expression),
+    })
+}
+
+// Expression
+
+fn expression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Expression> {
+    parcel::join(
+        subexpression(),
+        parcel::zero_or_more(parcel::right(parcel::join(
+            expect_character('|'),
+            subexpression(),
+        ))),
+    )
+    .map(|(head, tail)| vec![head].into_iter().chain(tail).collect())
+    .map(ast::Expression)
+}
+
+fn subexpression<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::SubExpression> {
+    parcel::one_or_more(subexpression_item()).map(ast::SubExpression)
+}
+
+fn subexpression_item<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::SubExpressionItem>
+{
+    parcel::or(group().map(Into::into), || {
+        parcel::or(backreference().map(Into::into), || {
+            parcel::or(anchor().map(Into::into), || r#match().map(Into::into))
+        })
+    })
+}
+
+// Group
+
+fn group<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Group> {
+    parcel::right(parcel::join(
+        expect_character('('),
+        parcel::optional(group_non_capturing_modifier())
+            .map(|non_capturing| non_capturing.is_some()),
+    ))
+    .and_then(|non_capturing| {
+        parcel::join(
+            expression().map(|expr| expr),
+            parcel::right(parcel::join(
+                expect_character(')'),
+                parcel::optional(quantifier()),
+            )),
+        )
+        .map(move |expr_and_qualifier| (non_capturing, expr_and_qualifier))
+    })
+    .map(|(is_non_capturing, (expression, quantifier))| {
+        match (is_non_capturing, quantifier) {
+            (true, None) => ast::Group::NonCapturing { expression },
+            (true, Some(quantifier)) => ast::Group::NonCapturingWithQuantifier {
+                expression,
+                quantifier,
+            },
+            (false, None) => ast::Group::Capturing { expression },
+            (false, Some(quantifier)) => ast::Group::CapturingWithQuantifier {
+                expression,
+                quantifier,
+            },
+        }
+    })
+}
+
+fn group_non_capturing_modifier<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::GroupNonCapturingModifier> {
+    parcel::join(expect_character('?'), expect_character(':'))
+        .map(|_| ast::GroupNonCapturingModifier)
+}
+
+// Matchers
+
+fn r#match<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Match> {
+    parcel::join(match_item(), parcel::optional(quantifier())).map(|(match_item, quantifier)| {
+        match quantifier {
+            Some(quantifier) => ast::Match::WithQuantifier {
+                item: match_item,
+                quantifier,
+            },
+            None => ast::Match::WithoutQuantifier { item: match_item },
+        }
+    })
+}
+
+fn match_item<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::MatchItem> {
+    parcel::or(match_character_class().map(Into::into), || {
+        parcel::or(match_any_character().map(Into::into), || {
+            match_character().map(Into::into)
+        })
+    })
+}
+
+fn match_any_character<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::MatchAnyCharacter>
+{
+    expect_character('.').map(|_| ast::MatchAnyCharacter)
+}
+
+fn match_character_class<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::MatchCharacterClass> {
+    parcel::or(
+        character_group().map(ast::MatchCharacterClass::CharacterGroup),
+        || {
+            parcel::or(
+                character_class().map(ast::MatchCharacterClass::CharacterClass),
+                || {
+                    character_class_from_unicode_category()
+                        .map(ast::MatchCharacterClass::CharacterClassFromUnicodeCategory)
+                },
+            )
+        },
+    )
+}
+
+fn match_character<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::MatchCharacter> {
+    char()
+        .predicate(|c| ![')', '|'].contains(&c.as_char()))
+        .map(ast::MatchCharacter)
+}
+
+// Character Classes
+
+fn character_group<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterGroup> {
+    parcel::join(
+        parcel::right(parcel::join(
+            expect_character('[').map(|c| c),
+            parcel::optional(character_group_negative_modifier())
+                .map(|negation| negation.is_some()),
+        )),
+        parcel::left(parcel::join(
+            parcel::one_or_more(character_group_item()),
+            expect_character(']'),
+        )),
+    )
+    .map(|(negation, character_group_items)| match negation {
+        true => ast::CharacterGroup::NegatedItems(character_group_items),
+        false => ast::CharacterGroup::Items(character_group_items),
+    })
+}
+
+fn character_group_negative_modifier<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterGroupNegativeModifier> {
+    expect_character('^').map(|_| ast::CharacterGroupNegativeModifier)
+}
+
+fn character_group_item<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterGroupItem> {
+    parcel::or(character_class().map(Into::into), || {
+        parcel::or(
+            character_class_from_unicode_category().map(Into::into),
+            || {
+                parcel::or(character_range().map(Into::into), || {
+                    char().predicate(|ast::Char(c)| *c != ']').map(Into::into)
+                })
+            },
+        )
+    })
+}
+
+fn character_class<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterClass> {
+    parcel::or(character_class_any_word().map(Into::into), || {
+        parcel::or(character_class_any_word_inverted().map(Into::into), || {
+            parcel::or(character_class_any_decimal_digit().map(Into::into), || {
+                character_class_any_decimal_digit_inverted().map(Into::into)
+            })
+        })
+    })
+}
+
+fn character_class_any_word<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterClassAnyWord> {
+    parcel::join(expect_character('\\'), expect_character('w')).map(|_| ast::CharacterClassAnyWord)
+}
+
+fn character_class_any_word_inverted<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterClassAnyWordInverted> {
+    parcel::join(expect_character('\\'), expect_character('W'))
+        .map(|_| ast::CharacterClassAnyWordInverted)
+}
+
+fn character_class_any_decimal_digit<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterClassAnyDecimalDigit> {
+    parcel::join(expect_character('\\'), expect_character('d'))
+        .map(|_| ast::CharacterClassAnyDecimalDigit)
+}
+
+fn character_class_any_decimal_digit_inverted<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterClassAnyDecimalDigitInverted> {
+    parcel::join(expect_character('\\'), expect_character('D'))
+        .map(|_| ast::CharacterClassAnyDecimalDigitInverted)
+}
+
+fn character_class_from_unicode_category<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterClassFromUnicodeCategory> {
+    parcel::right(parcel::join(
+        parcel::join(expect_character('\\'), expect_character('p')),
+        parcel::right(parcel::join(
+            expect_character('{'),
+            parcel::left(parcel::join(unicode_category_name(), expect_character('}'))),
+        )),
+    ))
+    .map(ast::CharacterClassFromUnicodeCategory)
+}
+
+fn unicode_category_name<'a>(
+) -> impl parcel::Parser<'a, &'a [(usize, char)], ast::UnicodeCategoryName> {
+    letters().map(ast::UnicodeCategoryName)
+}
+
+fn character_range<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::CharacterRange> {
+    parcel::join(
+        char(),
+        parcel::right(parcel::join(expect_character('-'), char())),
+    )
+    .map(|(lower_bound, upper_bound)| ast::CharacterRange::new(lower_bound, upper_bound))
+}
+
+// Quantifiers
+
+/// Represents all variants of regex quantifiers with an optionally lazy modifier.
+fn quantifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Quantifier> {
+    parcel::join(quantifier_type(), parcel::optional(lazy_modifier())).map(
+        |(quantifier_ty, lazy_modifier)| match lazy_modifier {
+            Some(_) => ast::Quantifier::Lazy(quantifier_ty),
+            None => ast::Quantifier::Eager(quantifier_ty),
+        },
+    )
+}
+
+fn lazy_modifier<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::LazyModifier> {
+    expect_character('?').map(|_| ast::LazyModifier)
+}
+
+fn quantifier_type<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::QuantifierType> {
+    parcel::or(zero_or_more_quantifier().map(Into::into), || {
+        parcel::or(one_or_more_quantifier().map(Into::into), || {
+            parcel::or(zero_or_one_quantifier().map(Into::into), || {
+                range_quantifier().map(Into::into)
+            })
+        })
+    })
+}
+
+fn range_quantifier<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::RangeQuantifier> {
+    parcel::left(parcel::join(
+        parcel::right(parcel::join(
+            expect_character('{'),
+            parcel::join(
+                range_quantifier_lower_bound(),
+                parcel::optional(parcel::right(parcel::join(
+                    expect_character(','),
+                    parcel::optional(range_quantifier_upper_bound()),
+                ))),
+            ),
+        )),
+        expect_character('}'),
+    ))
+    .map(|(lower_bound, upper_bound)| ast::RangeQuantifier::new(lower_bound, upper_bound))
+}
+
+fn range_quantifier_lower_bound<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::RangeQuantifierLowerBound> {
+    integer().map(ast::RangeQuantifierLowerBound)
+}
+
+fn range_quantifier_upper_bound<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::RangeQuantifierUpperBound> {
+    integer().map(ast::RangeQuantifierUpperBound)
+}
+
+fn zero_or_more_quantifier<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::QuantifierType> {
+    expect_character('*').map(|_| ast::QuantifierType::ZeroOrMore)
+}
+
+fn one_or_more_quantifier<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::QuantifierType> {
+    expect_character('+').map(|_| ast::QuantifierType::OneOrMore)
+}
+
+fn zero_or_one_quantifier<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::QuantifierType> {
+    expect_character('?').map(|_| ast::QuantifierType::ZeroOrOne)
+}
+
+// Backreferences
+
+fn backreference<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::Backreference> {
+    parcel::right(parcel::join(expect_character('\\'), integer())).map(ast::Backreference)
+}
+
+// Anchors
+
+fn start_of_string_anchor<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::StartOfStringAnchor> {
+    expect_character('^').map(|_| ast::StartOfStringAnchor)
+}
+
+fn anchor<'a>() -> impl parcel::Parser<'a, &'a [(usize, char)], ast::Anchor> {
+    parcel::or(anchor_word_boundary().map(Into::into), || {
+        parcel::or(anchor_nonword_boundary().map(Into::into), || {
+            parcel::or(anchor_start_of_string_only().map(Into::into), || {
+                parcel::or(
+                    anchor_end_of_string_only_not_newline().map(Into::into),
+                    || {
+                        parcel::or(anchor_end_of_string_only().map(Into::into), || {
+                            parcel::or(anchor_previous_match_end().map(Into::into), || {
+                                anchor_end_of_string().map(Into::into)
+                            })
+                        })
+                    },
+                )
+            })
+        })
+    })
+}
+
+fn anchor_word_boundary<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::AnchorWordBoundary> {
+    parcel::join(expect_character('\\'), expect_character('b')).map(|_| ast::AnchorWordBoundary)
+}
+
+fn anchor_nonword_boundary<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::AnchorNonWordBoundary>
+{
+    parcel::join(expect_character('\\'), expect_character('B')).map(|_| ast::AnchorNonWordBoundary)
+}
+
+fn anchor_start_of_string_only<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::AnchorStartOfStringOnly> {
+    parcel::join(expect_character('\\'), expect_character('A'))
+        .map(|_| ast::AnchorStartOfStringOnly)
+}
+
+fn anchor_end_of_string_only_not_newline<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::AnchorEndOfStringOnlyNotNewline> {
+    parcel::join(expect_character('\\'), expect_character('z'))
+        .map(|_| ast::AnchorEndOfStringOnlyNotNewline)
+}
+
+fn anchor_end_of_string_only<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::AnchorEndOfStringOnly> {
+    parcel::join(expect_character('\\'), expect_character('Z')).map(|_| ast::AnchorEndOfStringOnly)
+}
+
+fn anchor_previous_match_end<'a>(
+) -> impl Parser<'a, &'a [(usize, char)], ast::AnchorPreviousMatchEnd> {
+    parcel::join(expect_character('\\'), expect_character('G')).map(|_| ast::AnchorPreviousMatchEnd)
+}
+
+fn anchor_end_of_string<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::AnchorEndOfString> {
+    expect_character('$').map(|_| ast::AnchorEndOfString)
+}
+
+// Terminals
+
+fn integer<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::Integer> {
+    move |input: &'a [(usize, char)]| {
+        let preparsed_input = input;
+        let res = parcel::join(
+            expect_character('-').optional(),
+            parcel::one_or_more(digit(10)),
+        )
+        .map(|(negative, digits)| {
+            let vd: String = match negative {
+                Some(_) => "-",
+                None => "",
+            }
+            .chars()
+            .chain(digits.into_iter())
+            .collect();
+
+            vd.parse::<isize>()
+        })
+        .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match {
+                span,
+                remainder,
+                inner: Ok(int),
+            }) => Ok(MatchStatus::Match {
+                span,
+                remainder,
+                inner: ast::Integer(int),
+            }),
+
+            Ok(MatchStatus::Match {
+                span: _,
+                remainder: _,
+                inner: Err(_),
+            }) => Ok(MatchStatus::NoMatch(preparsed_input)),
+
+            Ok(MatchStatus::NoMatch(remainder)) => Ok(MatchStatus::NoMatch(remainder)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn letters<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::Letters> {
+    parcel::one_or_more(alphabetic().predicate(|c| c.is_ascii_alphabetic())).map(ast::Letters)
+}
+
+fn char<'a>() -> impl Parser<'a, &'a [(usize, char)], ast::Char> {
+    any_character_escaped().map(ast::Char)
+}
+
+fn any_character_escaped<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
+    move |input: &'a [(usize, char)]| match input.get(0..2) {
+        Some(&[(escape_pos, '\\'), (to_escape_pos, to_escape)]) => {
+            match char_to_escaped_equivalent(to_escape) {
+                Some(escaped_char) => Ok(MatchStatus::Match {
+                    span: escape_pos..to_escape_pos + 1,
+                    remainder: &input[2..],
+                    inner: escaped_char,
+                }),
+                None => Ok(MatchStatus::NoMatch(input)),
+            }
+        }
+        // discard the lookahead.
+        Some(&[(next_pos, next), _]) => Ok(MatchStatus::Match {
+            span: next_pos..next_pos + 1,
+            remainder: &input[1..],
+            inner: next,
+        }),
+        // handle for end of input
+        None => match input.get(0..1) {
+            // discard the lookahead.
+            Some(&[(next_pos, next)]) => Ok(MatchStatus::Match {
+                span: next_pos..next_pos + 1,
+                remainder: &input[1..],
+                inner: next,
+            }),
+            _ => Ok(MatchStatus::NoMatch(input)),
+        },
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+fn char_to_escaped_equivalent(c: char) -> Option<char> {
+    match c {
+        'n' => Some('\n'),
+        't' => Some('\t'),
+        'r' => Some('\r'),
+        '\'' => Some('\''),
+        '\"' => Some('\"'),
+        '\\' => Some('\\'),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_minimal_expression_with_no_errors() {
+        let inputs = vec![
+            // a basic input string
+            "the red pill",
+            // A recursive grouping
+            "the ((red|blue) pill)",
+        ]
+        .into_iter()
+        .map(|input| input.chars().enumerate().collect::<Vec<(usize, char)>>());
+
+        for input in inputs {
+            let parse_result = parse(&input);
+            assert!(parse_result.is_ok())
+        }
+    }
+
+    #[test]
+    fn should_parse_compound_match() {
+        use ast::*;
+        let input = "ab".chars().enumerate().collect::<Vec<(usize, char)>>();
+
+        assert_eq!(
+            Ok(Regex::Unanchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Match(Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacter(MatchCharacter(Char('a')))
+                }),
+                SubExpressionItem::Match(Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacter(MatchCharacter(Char('b')))
+                }),
+            ])]))),
+            parse(&input)
+        )
+    }
+
+    #[test]
+    fn should_parse_anchored_match() {
+        use ast::*;
+        let input = "^ab".chars().enumerate().collect::<Vec<(usize, char)>>();
+
+        assert_eq!(
+            Ok(Regex::StartOfStringAnchored(Expression(vec![
+                SubExpression(vec![
+                    SubExpressionItem::Match(Match::WithoutQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a')))
+                    }),
+                    SubExpressionItem::Match(Match::WithoutQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('b')))
+                    }),
+                ])
+            ]))),
+            parse(&input)
+        )
+    }
+
+    #[test]
+    fn should_parse_alternation() {
+        use ast::*;
+        let input = "^a|b".chars().enumerate().collect::<Vec<(usize, char)>>();
+
+        assert_eq!(
+            Ok(Regex::StartOfStringAnchored(Expression(vec![
+                SubExpression(vec![SubExpressionItem::Match(Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacter(MatchCharacter(Char('a')))
+                }),]),
+                SubExpression(vec![SubExpressionItem::Match(Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacter(MatchCharacter(Char('b')))
+                }),])
+            ]))),
+            parse(&input)
+        )
+    }
+
+    #[test]
+    fn should_parse_eager_repetition_quantifiers() {
+        use ast::*;
+
+        let inputs = vec![
+            (QuantifierType::OneOrMore, "^.+"),
+            (QuantifierType::ZeroOrMore, "^.*"),
+            (QuantifierType::MatchExactRange(Integer(2)), "^.{2}"),
+            (QuantifierType::MatchAtLeastRange(Integer(2)), "^.{2,}"),
+            (
+                QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                },
+                "^.{2,4}",
+            ),
+        ];
+
+        for (expected_quantifier, input) in inputs {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            assert_eq!(
+                Ok(Regex::StartOfStringAnchored(Expression(vec![
+                    SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                        item: MatchItem::MatchAnyCharacter,
+                        quantifier: Quantifier::Eager(expected_quantifier),
+                    })])
+                ]))),
+                parse(&input)
+            )
+        }
+
+        // test single character matches
+        let inputs = vec![(QuantifierType::MatchExactRange(Integer(2)), "^a{2}")];
+
+        for (expected_quantifier, input) in inputs {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            assert_eq!(
+                Ok(Regex::StartOfStringAnchored(Expression(vec![
+                    SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                        quantifier: Quantifier::Eager(expected_quantifier),
+                    })])
+                ]))),
+                parse(&input)
+            )
+        }
+    }
+
+    #[test]
+    fn should_parse_lazy_repetition_quantifiers() {
+        use ast::*;
+
+        let inputs = vec![
+            (QuantifierType::OneOrMore, "^.+?"),
+            (QuantifierType::ZeroOrMore, "^.*?"),
+            (QuantifierType::MatchExactRange(Integer(2)), "^.{2}?"),
+            (QuantifierType::MatchAtLeastRange(Integer(2)), "^.{2,}?"),
+            (
+                QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(2),
+                    upper_bound: Integer(4),
+                },
+                "^.{2,4}?",
+            ),
+        ];
+
+        for (expected_quantifier, input) in inputs {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            assert_eq!(
+                Ok(Regex::StartOfStringAnchored(Expression(vec![
+                    SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                        item: MatchItem::MatchAnyCharacter,
+                        quantifier: Quantifier::Lazy(expected_quantifier),
+                    })])
+                ]))),
+                parse(&input)
+            )
+        }
+
+        // test single character matches
+        let inputs = vec![(QuantifierType::MatchExactRange(Integer(2)), "^a{2}?")];
+
+        for (expected_quantifier, input) in inputs {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            assert_eq!(
+                Ok(Regex::StartOfStringAnchored(Expression(vec![
+                    SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                        item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                        quantifier: Quantifier::Lazy(expected_quantifier),
+                    })])
+                ]))),
+                parse(&input)
+            )
+        }
+    }
+
+    #[test]
+    fn should_parse_character_class_items() {
+        use ast::*;
+        let input_output = vec![
+            (
+                "^\\w",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                },
+            ),
+            (
+                "^\\w?",
+                Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                    quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+                },
+            ),
+            (
+                "^\\w*",
+                Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                    quantifier: Quantifier::Eager(QuantifierType::ZeroOrMore),
+                },
+            ),
+            (
+                "^\\w+",
+                Match::WithQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWord,
+                    )),
+                    quantifier: Quantifier::Eager(QuantifierType::OneOrMore),
+                },
+            ),
+            (
+                "^\\W",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyWordInverted,
+                    )),
+                },
+            ),
+            (
+                "^\\d",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyDecimalDigit,
+                    )),
+                },
+            ),
+            (
+                "^\\D",
+                Match::WithoutQuantifier {
+                    item: MatchItem::MatchCharacterClass(MatchCharacterClass::CharacterClass(
+                        CharacterClass::AnyDecimalDigitInverted,
+                    )),
+                },
+            ),
+        ];
+
+        for (test_id, (input, class)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(class)])
+                    ])))
+                ),
+                (test_id, res)
+            )
+        }
+    }
+
+    #[test]
+    fn should_parse_character_group_items() {
+        use ast::*;
+
+        let input_output = vec![
+            (
+                "^[a]",
+                CharacterGroup::Items(vec![CharacterGroupItem::Char(Char('a'))]),
+            ),
+            (
+                "^[ab]",
+                CharacterGroup::Items(vec![
+                    CharacterGroupItem::Char(Char('a')),
+                    CharacterGroupItem::Char(Char('b')),
+                ]),
+            ),
+            (
+                "^[a-z]",
+                CharacterGroup::Items(vec![CharacterGroupItem::CharacterRange(
+                    Char('a'),
+                    Char('z'),
+                )]),
+            ),
+            (
+                "^[abc0-9]",
+                CharacterGroup::Items(vec![
+                    CharacterGroupItem::Char(Char('a')),
+                    CharacterGroupItem::Char(Char('b')),
+                    CharacterGroupItem::Char(Char('c')),
+                    CharacterGroupItem::CharacterRange(Char('0'), Char('9')),
+                ]),
+            ),
+        ];
+
+        for (test_id, (input, output)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(Match::WithoutQuantifier {
+                            item: MatchItem::MatchCharacterClass(
+                                MatchCharacterClass::CharacterGroup(output)
+                            )
+                        }),])
+                    ])))
+                ),
+                (test_id, res)
+            )
+        }
+
+        // with quantifiers
+        let input_output = vec![
+            ("^[ab]?", QuantifierType::ZeroOrOne),
+            ("^[ab]*", QuantifierType::ZeroOrMore),
+            ("^[ab]+", QuantifierType::OneOrMore),
+            ("^[ab]{1}", QuantifierType::MatchExactRange(Integer(1))),
+            ("^[ab]{1,}", QuantifierType::MatchAtLeastRange(Integer(1))),
+            (
+                "^[ab]{1,2}",
+                QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(1),
+                    upper_bound: Integer(2),
+                },
+            ),
+        ];
+
+        for (test_id, (input, quantifier_ty)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                            item: MatchItem::MatchCharacterClass(
+                                MatchCharacterClass::CharacterGroup(CharacterGroup::Items(vec![
+                                    CharacterGroupItem::Char(Char('a')),
+                                    CharacterGroupItem::Char(Char('b')),
+                                ]))
+                            ),
+                            quantifier: Quantifier::Eager(quantifier_ty)
+                        }),])
+                    ])))
+                ),
+                (test_id, res)
+            )
+        }
+    }
+
+    #[test]
+    fn should_parse_group_items() {
+        use ast::*;
+
+        let input_output = vec![
+            (
+                "^(a)",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                        ])]),
+                    }),
+                ])])),
+            ),
+            (
+                "^(a)?",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::CapturingWithQuantifier {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                        ])]),
+                        quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+                    }),
+                ])])),
+            ),
+            (
+                "^(a)(b)",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                        ])]),
+                    }),
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+                            }),
+                        ])]),
+                    }),
+                ])])),
+            ),
+            (
+                "^(a(b))",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::Capturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                            SubExpressionItem::Group(Group::Capturing {
+                                expression: Expression(vec![SubExpression(vec![
+                                    SubExpressionItem::Match(Match::WithoutQuantifier {
+                                        item: MatchItem::MatchCharacter(MatchCharacter(Char('b'))),
+                                    }),
+                                ])]),
+                            }),
+                        ])]),
+                    }),
+                ])])),
+            ),
+            (
+                "^(?:a)",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::NonCapturing {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                        ])]),
+                    }),
+                ])])),
+            ),
+            (
+                "^(?:a)?",
+                Regex::StartOfStringAnchored(Expression(vec![SubExpression(vec![
+                    SubExpressionItem::Group(Group::NonCapturingWithQuantifier {
+                        expression: Expression(vec![SubExpression(vec![
+                            SubExpressionItem::Match(Match::WithoutQuantifier {
+                                item: MatchItem::MatchCharacter(MatchCharacter(Char('a'))),
+                            }),
+                        ])]),
+                        quantifier: Quantifier::Eager(QuantifierType::ZeroOrOne),
+                    }),
+                ])])),
+            ),
+        ];
+
+        for (test_id, (input, expected_regex_ast)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!((test_id, Ok(expected_regex_ast)), (test_id, res))
+        }
+
+        // with quantifiers
+        let input_output = vec![
+            ("^[ab]?", QuantifierType::ZeroOrOne),
+            ("^[ab]*", QuantifierType::ZeroOrMore),
+            ("^[ab]+", QuantifierType::OneOrMore),
+            ("^[ab]{1}", QuantifierType::MatchExactRange(Integer(1))),
+            ("^[ab]{1,}", QuantifierType::MatchAtLeastRange(Integer(1))),
+            (
+                "^[ab]{1,2}",
+                QuantifierType::MatchBetweenRange {
+                    lower_bound: Integer(1),
+                    upper_bound: Integer(2),
+                },
+            ),
+        ];
+
+        for (test_id, (input, quantifier_ty)) in input_output.into_iter().enumerate() {
+            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+            let res = parse(&input);
+            assert_eq!(
+                (
+                    test_id,
+                    Ok(Regex::StartOfStringAnchored(Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
+                            item: MatchItem::MatchCharacterClass(
+                                MatchCharacterClass::CharacterGroup(CharacterGroup::Items(vec![
+                                    CharacterGroupItem::Char(Char('a')),
+                                    CharacterGroupItem::Char(Char('b')),
+                                ]))
+                            ),
+                            quantifier: Quantifier::Eager(quantifier_ty)
+                        }),])
+                    ])))
+                ),
+                (test_id, res)
+            )
+        }
+    }
+
+    #[test]
+    fn should_parse_any_match() {
+        use ast::*;
+        let input = ".".chars().enumerate().collect::<Vec<(usize, char)>>();
+
+        assert_eq!(
+            Ok(Regex::Unanchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Match(Match::WithoutQuantifier {
+                    item: MatchItem::MatchAnyCharacter
+                }),
+            ])]))),
+            parse(&input)
+        )
+    }
+}

--- a/docs/regex.ebnf
+++ b/docs/regex.ebnf
@@ -1,0 +1,120 @@
+Regex ::= StartOfStringAnchor? Expression
+
+Expression ::= Subexpression ("|" Expression)?
+
+/* Anything that can be on one side of the alternation. */
+Subexpression ::= SubexpressionItem+
+SubexpressionItem
+	::= Match
+	  | Group
+	  | Anchor
+	  | Backreference
+	
+
+/* Grouping Constructs 
+------------------------------------------------------------------*/
+
+Group ::= "(" GroupNonCapturingModifier? Expression ")" Quantifier?
+GroupNonCapturingModifier ::= "?:"
+
+/* Match
+------------------------------------------------------------------*/
+
+Match ::= MatchItem Quantifier?
+
+MatchItem
+	::= MatchAnyCharacter
+	  | MatchCharacterClass
+	  | MatchCharacter
+
+MatchAnyCharacter ::= "."
+
+MatchCharacterClass
+	::= CharacterGroup
+	  | CharacterClass
+	  | CharacterClassFromUnicodeCategory
+
+MatchCharacter ::= Char
+
+/* Character Classes
+------------------------------------------------------------------*/
+
+CharacterGroup ::= "[" CharacterGroupNegativeModifier? CharacterGroupItem+ "]"
+
+CharacterGroupNegativeModifier ::= "^"
+CharacterGroupItem
+	::= CharacterClass
+	  | CharacterClassFromUnicodeCategory
+	  | CharacterRange
+	  | Char /* excluding ] */
+
+CharacterClass
+	::= CharacterClassAnyWord
+	  | CharacterClassAnyWordInverted
+	  | CharacterClassAnyDecimalDigit
+	  | CharacterClassAnyDecimalDigitInverted
+
+CharacterClassAnyWord ::= "\w"
+CharacterClassAnyWordInverted ::= "\W"
+CharacterClassAnyDecimalDigit ::= "\d"
+CharacterClassAnyDecimalDigitInverted ::= "\D"
+
+CharacterClassFromUnicodeCategory ::= "\p{" UnicodeCategoryName "}"
+UnicodeCategoryName ::= Letters
+
+CharacterRange ::= Char "-" Char
+
+
+/* Quantifiers 
+------------------------------------------------------------------*/
+
+Quantifier ::= QuantifierType LazyModifier?
+QuantifierType
+	::= ZeroOrMoreQuantifier
+	  | OneOrMoreQuantifier
+	  | ZeroOrOneQuantifier
+	  | RangeQuantifier
+
+LazyModifier ::= "?"
+
+ZeroOrMoreQuantifier ::= "*"
+OneOrMoreQuantifier ::= "+"
+ZeroOrOneQuantifier ::= "?"
+
+RangeQuantifier ::= "{" RangeQuantifierLowerBound ( "," RangeQuantifierUpperBound? )? "}"
+RangeQuantifierLowerBound ::= Integer
+RangeQuantifierUpperBound ::= Integer
+
+/* Backreferences
+------------------------------------------------------------------*/
+
+Backreference ::= "\" Integer
+
+/* Anchors
+------------------------------------------------------------------*/
+
+StartOfStringAnchor ::= "^"
+
+Anchor
+	::= AnchorWordBoundary
+	  | AnchorNonWordBoundary
+	  | AnchorStartOfStringOnly
+	  | AnchorEndOfStringOnlyNotNewline
+	  | AnchorEndOfStringOnly
+	  | AnchorPreviousMatchEnd
+	  | AnchorEndOfString
+
+AnchorWordBoundary ::= "\b"
+AnchorNonWordBoundary ::= "\B"
+AnchorStartOfStringOnly ::= "\A"
+AnchorEndOfStringOnlyNotNewline ::= "\z"
+AnchorEndOfStringOnly ::= "\Z"
+AnchorPreviousMatchEnd ::= "\G"
+AnchorEndOfString ::= "$"
+
+/* Misc
+------------------------------------------------------------------*/
+
+Integer ::= [0-9]+
+Letters ::= [a-zA-Z]+
+Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]

--- a/docs/regex.xhtml
+++ b/docs/regex.xhtml
@@ -1,0 +1,1534 @@
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <meta name="generator" content="Railroad Diagram Generator 1.63" />
+      <style type="text/css">
+    ::-moz-selection
+    {
+      color: #FFFCF0;
+      background: #0F0C00;
+    }
+    ::selection
+    {
+      color: #FFFCF0;
+      background: #0F0C00;
+    }
+    .ebnf a, .grammar a
+    {
+      text-decoration: none;
+    }
+    .ebnf a:hover, .grammar a:hover
+    {
+      color: #050400;
+      text-decoration: underline;
+    }
+    .signature
+    {
+      color: #806600;
+      font-size: 11px;
+      text-align: right;
+    }
+    body
+    {
+      font: normal 12px Verdana, sans-serif;
+      color: #0F0C00;
+      background: #FFFCF0;
+    }
+    a:link, a:visited
+    {
+      color: #0F0C00;
+    }
+    a:link.signature, a:visited.signature
+    {
+      color: #806600;
+    }
+    a.button, #tabs li a
+    {
+      padding: 0.25em 0.5em;
+      border: 1px solid #806600;
+      background: #F1E8C6;
+      color: #806600;
+      text-decoration: none;
+      font-weight: bold;
+    }
+    a.button:hover, #tabs li a:hover
+    {
+      color: #050400;
+      background: #FFF6D1;
+      border-color: #050400;
+    }
+    #tabs
+    {
+      padding: 3px 10px;
+      margin-left: 0;
+      margin-top: 58px;
+      border-bottom: 1px solid #0F0C00;
+    }
+    #tabs li
+    {
+      list-style: none;
+      margin-left: 5px;
+      display: inline;
+    }
+    #tabs li a
+    {
+      border-bottom: 1px solid #0F0C00;
+    }
+    #tabs li a.active
+    {
+      color: #0F0C00;
+      background: #FFFCF0;
+      border-color: #0F0C00;
+      border-bottom: 1px solid #FFFCF0;
+      outline: none;
+    }
+    #divs div
+    {
+      display: none;
+      overflow:auto;
+    }
+    #divs div.active
+    {
+      display: block;
+    }
+    #text
+    {
+      border-color: #806600;
+      background: #FFFEFA;
+      color: #050400;
+    }
+    .small
+    {
+      vertical-align: top;
+      text-align: right;
+      font-size: 9px;
+      font-weight: normal;
+      line-height: 120%;
+    }
+    td.small
+    {
+      padding-top: 0px;
+    }
+    .hidden
+    {
+      visibility: hidden;
+    }
+    td:hover .hidden
+    {
+      visibility: visible;
+    }
+    div.download
+    {
+      display: none;
+      background: #FFFCF0;
+      position: absolute;
+      right: 34px;
+      top: 94px;
+      padding: 10px;
+      border: 1px dotted #0F0C00;
+    }
+    #divs div.ebnf, .ebnf code
+    {
+      display: block;
+      padding: 10px;
+      background: #FFF6D1;
+      width: 992px;
+    }
+    #divs div.grammar
+    {
+      display: block;
+      padding-left: 16px;
+      padding-top: 2px;
+      padding-bottom: 2px;
+      background: #FFF6D1;
+    }
+    pre
+    {
+      margin: 0px;
+    }
+    .ebnf div
+    {
+      padding-left: 13ch;
+      text-indent: -13ch;
+    }
+    .ebnf code, .grammar code, textarea, pre
+    {
+      font:12px SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
+    }
+    tr.option-line td:first-child
+    {
+      text-align: right
+    }
+    tr.option-text td
+    {
+      padding-bottom: 10px
+    }
+    table.palette
+    {
+      border-top: 1px solid #050400;
+      border-right: 1px solid #050400;
+      margin-bottom: 4px
+    }
+    td.palette
+    {
+      border-bottom: 1px solid #050400;
+      border-left: 1px solid #050400;
+    }
+    a.palette
+    {
+      padding: 2px 3px 2px 10px;
+      text-decoration: none;
+    }
+    .palette
+    {
+      -webkit-user-select: none;
+      -khtml-user-select: none;
+      -moz-user-select: none;
+      -o-user-select: none;
+      -ms-user-select: none;
+    }
+  </style><svg xmlns="http://www.w3.org/2000/svg">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs></svg></head>
+   <body>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Regex">Regex:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="239" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">^</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Expression" xlink:title="Expression">
+            <rect x="121" y="3" width="90" height="32"></rect>
+            <rect x="119" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="129" y="21">Expression</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -32 h10 m90 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="229 17 237 13 237 21"></polygon>
+         <polygon points="229 17 221 13 221 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Regex" title="Regex">Regex</a>    ::= '^'? <a href="#Expression" title="Expression">Expression</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">no references</xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Expression">Expression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="213" height="81">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Subexpression" xlink:title="Subexpression">
+            <rect x="51" y="47" width="114" height="32"></rect>
+            <rect x="49" y="45" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">Subexpression</text></a><rect x="51" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">|</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m26 0 h10 m0 0 h88 m23 44 h-3"></svg:path>
+         <polygon points="203 61 211 57 211 65"></polygon>
+         <polygon points="203 61 195 57 195 65"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Expression" title="Expression">Expression</a></div>
+               <div>         ::= <a href="#Subexpression" title="Subexpression">Subexpression</a> ( '|' <a href="#Subexpression" title="Subexpression">Subexpression</a> )*</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Group" title="Group">Group</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#Regex" title="Regex">Regex</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Subexpression">Subexpression:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="241" height="53">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#SubexpressionItem" xlink:title="SubexpressionItem">
+            <rect x="51" y="19" width="142" height="32"></rect>
+            <rect x="49" y="17" width="142" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="37">SubexpressionItem</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m20 0 h10 m142 0 h10 m-182 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m162 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-162 0 h10 m0 0 h152 m23 32 h-3"></svg:path>
+         <polygon points="231 33 239 29 239 37"></polygon>
+         <polygon points="231 33 223 29 223 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Subexpression" title="Subexpression">Subexpression</a></div>
+               <div>         ::= <a href="#SubexpressionItem" title="SubexpressionItem">SubexpressionItem</a>+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Expression" title="Expression">Expression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="SubexpressionItem">SubexpressionItem:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="209" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Match" xlink:title="Match">
+            <rect x="51" y="3" width="56" height="32"></rect>
+            <rect x="49" y="1" width="56" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">Match</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Group" xlink:title="Group">
+            <rect x="51" y="47" width="58" height="32"></rect>
+            <rect x="49" y="45" width="58" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">Group</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Anchor" xlink:title="Anchor">
+            <rect x="51" y="91" width="64" height="32"></rect>
+            <rect x="49" y="89" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">Anchor</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Backreference" xlink:title="Backreference">
+            <rect x="51" y="135" width="110" height="32"></rect>
+            <rect x="49" y="133" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">Backreference</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h54 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m58 0 h10 m0 0 h52 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m64 0 h10 m0 0 h46 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m23 -132 h-3"></svg:path>
+         <polygon points="199 17 207 13 207 21"></polygon>
+         <polygon points="199 17 191 13 191 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#SubexpressionItem" title="SubexpressionItem">SubexpressionItem</a></div>
+               <div>         ::= <a href="#Match" title="Match">Match</a></div>
+               <div>           | <a href="#Group" title="Group">Group</a></div>
+               <div>           | <a href="#Anchor" title="Anchor">Anchor</a></div>
+               <div>           | <a href="#Backreference" title="Backreference">Backreference</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Subexpression" title="Subexpression">Subexpression</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Group">Group:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="475" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">(</text>
+         <rect x="97" y="35" width="32" height="32" rx="10"></rect>
+         <rect x="95" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="105" y="53">?:</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Expression" xlink:title="Expression">
+            <rect x="169" y="3" width="90" height="32"></rect>
+            <rect x="167" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="177" y="21">Expression</text></a><rect x="279" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="277" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="21">)</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Quantifier" xlink:title="Quantifier">
+            <rect x="345" y="35" width="82" height="32"></rect>
+            <rect x="343" y="33" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="353" y="53">Quantifier</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h42 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v12 m72 0 v-12 m-72 12 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m32 0 h10 m20 -32 h10 m90 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="465 17 473 13 473 21"></polygon>
+         <polygon points="465 17 457 13 457 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Group" title="Group">Group</a>    ::= '(' '?:'? <a href="#Expression" title="Expression">Expression</a> ')' <a href="#Quantifier" title="Quantifier">Quantifier</a>?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#SubexpressionItem" title="SubexpressionItem">SubexpressionItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Match">Match:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="287" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#MatchItem" xlink:title="MatchItem">
+            <rect x="31" y="3" width="86" height="32"></rect>
+            <rect x="29" y="1" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">MatchItem</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Quantifier" xlink:title="Quantifier">
+            <rect x="157" y="35" width="82" height="32"></rect>
+            <rect x="155" y="33" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="53">Quantifier</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="277 17 285 13 285 21"></polygon>
+         <polygon points="277 17 269 13 269 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Match" title="Match">Match</a>    ::= <a href="#MatchItem" title="MatchItem">MatchItem</a> <a href="#Quantifier" title="Quantifier">Quantifier</a>?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#SubexpressionItem" title="SubexpressionItem">SubexpressionItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="MatchItem">MatchItem:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="253" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">.</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#MatchCharacterClass" xlink:title="MatchCharacterClass">
+            <rect x="51" y="47" width="154" height="32"></rect>
+            <rect x="49" y="45" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">MatchCharacterClass</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#MatchCharacter" xlink:title="MatchCharacter">
+            <rect x="51" y="91" width="120" height="32"></rect>
+            <rect x="49" y="89" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">MatchCharacter</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m24 0 h10 m0 0 h130 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m154 0 h10 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m120 0 h10 m0 0 h34 m23 -88 h-3"></svg:path>
+         <polygon points="243 17 251 13 251 21"></polygon>
+         <polygon points="243 17 235 13 235 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#MatchItem" title="MatchItem">MatchItem</a></div>
+               <div>         ::= '.'</div>
+               <div>           | <a href="#MatchCharacterClass" title="MatchCharacterClass">MatchCharacterClass</a></div>
+               <div>           | <a href="#MatchCharacter" title="MatchCharacter">MatchCharacter</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Match" title="Match">Match</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="MatchCharacterClass">MatchCharacterClass:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="355" height="125">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterGroup" xlink:title="CharacterGroup">
+            <rect x="51" y="3" width="120" height="32"></rect>
+            <rect x="49" y="1" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">CharacterGroup</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterClass" xlink:title="CharacterClass">
+            <rect x="51" y="47" width="116" height="32"></rect>
+            <rect x="49" y="45" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">CharacterClass</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterClassFromUnicodeCategory" xlink:title="CharacterClassFromUnicodeCategory">
+            <rect x="51" y="91" width="256" height="32"></rect>
+            <rect x="49" y="89" width="256" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">CharacterClassFromUnicodeCategory</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h136 m-296 0 h20 m276 0 h20 m-316 0 q10 0 10 10 m296 0 q0 -10 10 -10 m-306 10 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m116 0 h10 m0 0 h140 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m256 0 h10 m23 -88 h-3"></svg:path>
+         <polygon points="345 17 353 13 353 21"></polygon>
+         <polygon points="345 17 337 13 337 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#MatchCharacterClass" title="MatchCharacterClass">MatchCharacterClass</a></div>
+               <div>         ::= <a href="#CharacterGroup" title="CharacterGroup">CharacterGroup</a></div>
+               <div>           | <a href="#CharacterClass" title="CharacterClass">CharacterClass</a></div>
+               <div>           | <a href="#CharacterClassFromUnicodeCategory" title="CharacterClassFromUnicodeCategory">CharacterClassFromUnicodeCategory</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#MatchItem" title="MatchItem">MatchItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="MatchCharacter">MatchCharacter:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="109" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
+            <rect x="31" y="3" width="50" height="32"></rect>
+            <rect x="29" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">Char</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m50 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="99 17 107 13 107 21"></polygon>
+         <polygon points="99 17 91 13 91 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#MatchCharacter" title="MatchCharacter">MatchCharacter</a></div>
+               <div>         ::= <a href="#Char" title="Char">Char</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#MatchItem" title="MatchItem">MatchItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterGroup">CharacterGroup:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="431" height="85">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="31" y="19" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="17" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="37">[</text>
+         <rect x="97" y="51" width="30" height="32" rx="10"></rect>
+         <rect x="95" y="49" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="105" y="69">^</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterGroupItem" xlink:title="CharacterGroupItem">
+            <rect x="187" y="19" width="150" height="32"></rect>
+            <rect x="185" y="17" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="195" y="37">CharacterGroupItem</text></a><rect x="377" y="19" width="26" height="32" rx="10"></rect>
+         <rect x="375" y="17" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="385" y="37">]</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h40 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v12 m70 0 v-12 m-70 12 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m40 -32 h10 m150 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m170 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-170 0 h10 m0 0 h160 m20 32 h10 m26 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="421 33 429 29 429 37"></polygon>
+         <polygon points="421 33 413 29 413 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#CharacterGroup" title="CharacterGroup">CharacterGroup</a></div>
+               <div>         ::= '[' '^'? <a href="#CharacterGroupItem" title="CharacterGroupItem">CharacterGroupItem</a>+ ']'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#MatchCharacterClass" title="MatchCharacterClass">MatchCharacterClass</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterGroupItem">CharacterGroupItem:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="355" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterClass" xlink:title="CharacterClass">
+            <rect x="51" y="3" width="116" height="32"></rect>
+            <rect x="49" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">CharacterClass</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterClassFromUnicodeCategory" xlink:title="CharacterClassFromUnicodeCategory">
+            <rect x="51" y="47" width="256" height="32"></rect>
+            <rect x="49" y="45" width="256" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">CharacterClassFromUnicodeCategory</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#CharacterRange" xlink:title="CharacterRange">
+            <rect x="51" y="91" width="122" height="32"></rect>
+            <rect x="49" y="89" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">CharacterRange</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
+            <rect x="51" y="135" width="50" height="32"></rect>
+            <rect x="49" y="133" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">Char</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m116 0 h10 m0 0 h140 m-296 0 h20 m276 0 h20 m-316 0 q10 0 10 10 m296 0 q0 -10 10 -10 m-306 10 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m256 0 h10 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m122 0 h10 m0 0 h134 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m50 0 h10 m0 0 h206 m23 -132 h-3"></svg:path>
+         <polygon points="345 17 353 13 353 21"></polygon>
+         <polygon points="345 17 337 13 337 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#CharacterGroupItem" title="CharacterGroupItem">CharacterGroupItem</a></div>
+               <div>         ::= <a href="#CharacterClass" title="CharacterClass">CharacterClass</a></div>
+               <div>           | <a href="#CharacterClassFromUnicodeCategory" title="CharacterClassFromUnicodeCategory">CharacterClassFromUnicodeCategory</a></div>
+               <div>           | <a href="#CharacterRange" title="CharacterRange">CharacterRange</a></div>
+               <div>           | <a href="#Char" title="Char">Char</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#CharacterGroup" title="CharacterGroup">CharacterGroup</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterClass">CharacterClass:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="141" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">\w</text>
+         <rect x="51" y="47" width="42" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="42" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">\W</text>
+         <rect x="51" y="91" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">\d</text>
+         <rect x="51" y="135" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">\D</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m40 0 h10 m0 0 h2 m-82 0 h20 m62 0 h20 m-102 0 q10 0 10 10 m82 0 q0 -10 10 -10 m-92 10 v24 m82 0 v-24 m-82 24 q0 10 10 10 m62 0 q10 0 10 -10 m-72 10 h10 m42 0 h10 m-72 -10 v20 m82 0 v-20 m-82 20 v24 m82 0 v-24 m-82 24 q0 10 10 10 m62 0 q10 0 10 -10 m-72 10 h10 m36 0 h10 m0 0 h6 m-72 -10 v20 m82 0 v-20 m-82 20 v24 m82 0 v-24 m-82 24 q0 10 10 10 m62 0 q10 0 10 -10 m-72 10 h10 m38 0 h10 m0 0 h4 m23 -132 h-3"></svg:path>
+         <polygon points="131 17 139 13 139 21"></polygon>
+         <polygon points="131 17 123 13 123 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#CharacterClass" title="CharacterClass">CharacterClass</a></div>
+               <div>         ::= '\w'</div>
+               <div>           | '\W'</div>
+               <div>           | '\d'</div>
+               <div>           | '\D'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#CharacterGroupItem" title="CharacterGroupItem">CharacterGroupItem</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#MatchCharacterClass" title="MatchCharacterClass">MatchCharacterClass</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterClassFromUnicodeCategory">CharacterClassFromUnicodeCategory:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="337" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="46" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">\p{</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#UnicodeCategoryName" xlink:title="UnicodeCategoryName">
+            <rect x="97" y="3" width="164" height="32"></rect>
+            <rect x="95" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="21">UnicodeCategoryName</text></a><rect x="281" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="279" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="289" y="21">}</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m46 0 h10 m0 0 h10 m164 0 h10 m0 0 h10 m28 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="327 17 335 13 335 21"></polygon>
+         <polygon points="327 17 319 13 319 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#CharacterClassFromUnicodeCategory" title="CharacterClassFromUnicodeCategory">CharacterClassFromUnicodeCategory</a></div>
+               <div>         ::= '\p{' <a href="#UnicodeCategoryName" title="UnicodeCategoryName">UnicodeCategoryName</a> '}'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#CharacterGroupItem" title="CharacterGroupItem">CharacterGroupItem</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#MatchCharacterClass" title="MatchCharacterClass">MatchCharacterClass</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="UnicodeCategoryName">UnicodeCategoryName:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="123" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Letters" xlink:title="Letters">
+            <rect x="31" y="3" width="64" height="32"></rect>
+            <rect x="29" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">Letters</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="113 17 121 13 121 21"></polygon>
+         <polygon points="113 17 105 13 105 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#UnicodeCategoryName" title="UnicodeCategoryName">UnicodeCategoryName</a></div>
+               <div>         ::= <a href="#Letters" title="Letters">Letters</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#CharacterClassFromUnicodeCategory" title="CharacterClassFromUnicodeCategory">CharacterClassFromUnicodeCategory</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="CharacterRange">CharacterRange:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="225" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
+            <rect x="31" y="3" width="50" height="32"></rect>
+            <rect x="29" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">Char</text></a><rect x="101" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="99" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="109" y="21">-</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Char" xlink:title="Char">
+            <rect x="147" y="3" width="50" height="32"></rect>
+            <rect x="145" y="1" width="50" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="21">Char</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m50 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m50 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="215 17 223 13 223 21"></polygon>
+         <polygon points="215 17 207 13 207 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#CharacterRange" title="CharacterRange">CharacterRange</a></div>
+               <div>         ::= <a href="#Char" title="Char">Char</a> '-' <a href="#Char" title="Char">Char</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#CharacterGroupItem" title="CharacterGroupItem">CharacterGroupItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Quantifier">Quantifier:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="257" height="69">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#QuantifierType" xlink:title="QuantifierType">
+            <rect x="31" y="3" width="112" height="32"></rect>
+            <rect x="29" y="1" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">QuantifierType</text></a><rect x="183" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="181" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="191" y="53">?</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m112 0 h10 m20 0 h10 m0 0 h36 m-66 0 h20 m46 0 h20 m-86 0 q10 0 10 10 m66 0 q0 -10 10 -10 m-76 10 v12 m66 0 v-12 m-66 12 q0 10 10 10 m46 0 q10 0 10 -10 m-56 10 h10 m26 0 h10 m23 -32 h-3"></svg:path>
+         <polygon points="247 17 255 13 255 21"></polygon>
+         <polygon points="247 17 239 13 239 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Quantifier" title="Quantifier">Quantifier</a></div>
+               <div>         ::= <a href="#QuantifierType" title="QuantifierType">QuantifierType</a> '?'?</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Group" title="Group">Group</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#Match" title="Match">Match</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="QuantifierType">QuantifierType:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="221" height="169">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">*</text>
+         <rect x="51" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">+</text>
+         <rect x="51" y="91" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">?</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#RangeQuantifier" xlink:title="RangeQuantifier">
+            <rect x="51" y="135" width="122" height="32"></rect>
+            <rect x="49" y="133" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">RangeQuantifier</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m28 0 h10 m0 0 h94 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m30 0 h10 m0 0 h92 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m26 0 h10 m0 0 h96 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m23 -132 h-3"></svg:path>
+         <polygon points="211 17 219 13 219 21"></polygon>
+         <polygon points="211 17 203 13 203 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#QuantifierType" title="QuantifierType">QuantifierType</a></div>
+               <div>         ::= '*'</div>
+               <div>           | '+'</div>
+               <div>           | '?'</div>
+               <div>           | <a href="#RangeQuantifier" title="RangeQuantifier">RangeQuantifier</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Quantifier" title="Quantifier">Quantifier</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="RangeQuantifier">RangeQuantifier:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="699" height="101">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">{</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#RangeQuantifierLowerBound" xlink:title="RangeQuantifierLowerBound">
+            <rect x="79" y="3" width="200" height="32"></rect>
+            <rect x="77" y="1" width="200" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="87" y="21">RangeQuantifierLowerBound</text></a><rect x="319" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="317" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="327" y="53">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#RangeQuantifierUpperBound" xlink:title="RangeQuantifierUpperBound">
+            <rect x="383" y="67" width="200" height="32"></rect>
+            <rect x="381" y="65" width="200" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="391" y="85">RangeQuantifierUpperBound</text></a><rect x="643" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="641" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="651" y="21">}</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m28 0 h10 m0 0 h10 m200 0 h10 m20 0 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-314 10 h10 m24 0 h10 m20 0 h10 m0 0 h210 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v12 m240 0 v-12 m-240 12 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m200 0 h10 m40 -64 h10 m28 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="689 17 697 13 697 21"></polygon>
+         <polygon points="689 17 681 13 681 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#RangeQuantifier" title="RangeQuantifier">RangeQuantifier</a></div>
+               <div>         ::= '{' <a href="#RangeQuantifierLowerBound" title="RangeQuantifierLowerBound">RangeQuantifierLowerBound</a> ( ',' <a href="#RangeQuantifierUpperBound" title="RangeQuantifierUpperBound">RangeQuantifierUpperBound</a>? )? '}'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#QuantifierType" title="QuantifierType">QuantifierType</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="RangeQuantifierLowerBound">RangeQuantifierLowerBound:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="125" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Integer" xlink:title="Integer">
+            <rect x="31" y="3" width="66" height="32"></rect>
+            <rect x="29" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">Integer</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="115 17 123 13 123 21"></polygon>
+         <polygon points="115 17 107 13 107 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#RangeQuantifierLowerBound" title="RangeQuantifierLowerBound">RangeQuantifierLowerBound</a></div>
+               <div>         ::= <a href="#Integer" title="Integer">Integer</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#RangeQuantifier" title="RangeQuantifier">RangeQuantifier</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="RangeQuantifierUpperBound">RangeQuantifierUpperBound:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="125" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Integer" xlink:title="Integer">
+            <rect x="31" y="3" width="66" height="32"></rect>
+            <rect x="29" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">Integer</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="115 17 123 13 123 21"></polygon>
+         <polygon points="115 17 107 13 107 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#RangeQuantifierUpperBound" title="RangeQuantifierUpperBound">RangeQuantifierUpperBound</a></div>
+               <div>         ::= <a href="#Integer" title="Integer">Integer</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#RangeQuantifier" title="RangeQuantifier">RangeQuantifier</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Backreference">Backreference:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="173" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="28" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">\</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#Integer" xlink:title="Integer">
+            <rect x="79" y="3" width="66" height="32"></rect>
+            <rect x="77" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="87" y="21">Integer</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m28 0 h10 m0 0 h10 m66 0 h10 m3 0 h-3"></svg:path>
+         <polygon points="163 17 171 13 171 21"></polygon>
+         <polygon points="163 17 155 13 155 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Backreference" title="Backreference">Backreference</a></div>
+               <div>         ::= '\' <a href="#Integer" title="Integer">Integer</a></div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#SubexpressionItem" title="SubexpressionItem">SubexpressionItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Anchor">Anchor:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="137" height="301">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">\b</text>
+         <rect x="51" y="47" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">\B</text>
+         <rect x="51" y="91" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">\A</text>
+         <rect x="51" y="135" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">\z</text>
+         <rect x="51" y="179" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">\Z</text>
+         <rect x="51" y="223" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">\G</text>
+         <rect x="51" y="267" width="28" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">$</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m36 0 h10 m0 0 h2 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m36 0 h10 m0 0 h2 m-68 -10 v20 m78 0 v-20 m-78 20 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m-68 -10 v20 m78 0 v-20 m-78 20 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m34 0 h10 m0 0 h4 m-68 -10 v20 m78 0 v-20 m-78 20 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m36 0 h10 m0 0 h2 m-68 -10 v20 m78 0 v-20 m-78 20 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m-68 -10 v20 m78 0 v-20 m-78 20 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m28 0 h10 m0 0 h10 m23 -264 h-3"></svg:path>
+         <polygon points="127 17 135 13 135 21"></polygon>
+         <polygon points="127 17 119 13 119 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Anchor" title="Anchor">Anchor</a>   ::= '\b'</div>
+               <div>           | '\B'</div>
+               <div>           | '\A'</div>
+               <div>           | '\z'</div>
+               <div>           | '\Z'</div>
+               <div>           | '\G'</div>
+               <div>           | '$'</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#SubexpressionItem" title="SubexpressionItem">SubexpressionItem</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Integer">Integer:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="161" height="53">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <polygon points="51 35 58 19 106 19 113 35 106 51 58 51"></polygon>
+         <polygon points="49 33 56 17 104 17 111 33 104 49 56 49" class="regexp"></polygon>
+         <text class="regexp" x="64" y="37">[0-9]</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m82 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-82 0 h10 m0 0 h72 m23 32 h-3"></svg:path>
+         <polygon points="151 33 159 29 159 37"></polygon>
+         <polygon points="151 33 143 29 143 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Integer" title="Integer">Integer</a>  ::= [0-9]+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#Backreference" title="Backreference">Backreference</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#RangeQuantifierLowerBound" title="RangeQuantifierLowerBound">RangeQuantifierLowerBound</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#RangeQuantifierUpperBound" title="RangeQuantifierUpperBound">RangeQuantifierUpperBound</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Letters">Letters:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="201" height="97">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <polygon points="71 35 78 19 124 19 131 35 124 51 78 51"></polygon>
+         <polygon points="69 33 76 17 122 17 129 33 122 49 76 49" class="regexp"></polygon>
+         <text class="regexp" x="84" y="37">[a-z]</text>
+         <polygon points="71 79 78 63 126 63 133 79 126 95 78 95"></polygon>
+         <polygon points="69 77 76 61 124 61 131 77 124 93 76 93" class="regexp"></polygon>
+         <text class="regexp" x="84" y="81">[A-Z]</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 33 h2 m40 0 h10 m60 0 h10 m0 0 h2 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m-122 -44 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m122 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-122 0 h10 m0 0 h112 m23 32 h-3"></svg:path>
+         <polygon points="191 33 199 29 199 37"></polygon>
+         <polygon points="191 33 183 29 183 37"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Letters" title="Letters">Letters</a>  ::= [a-zA-Z]+</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#UnicodeCategoryName" title="UnicodeCategoryName">UnicodeCategoryName</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml" style="font-size: 14px; font-weight:bold"><xhtml:a name="Char">Char:</xhtml:a></xhtml:p><svg xmlns="http://www.w3.org/2000/svg" width="263" height="257">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <polygon points="51 19 58 3 110 3 117 19 110 35 58 35"></polygon>
+         <polygon points="49 17 56 1 108 1 115 17 108 33 56 33" class="regexp"></polygon>
+         <text class="regexp" x="64" y="21">[#x9]</text>
+         <polygon points="51 63 58 47 110 47 117 63 110 79 58 79"></polygon>
+         <polygon points="49 61 56 45 108 45 115 61 108 77 56 77" class="regexp"></polygon>
+         <text class="regexp" x="64" y="65">[#xA]</text>
+         <polygon points="51 107 58 91 110 91 117 107 110 123 58 123"></polygon>
+         <polygon points="49 105 56 89 108 89 115 105 108 121 56 121" class="regexp"></polygon>
+         <text class="regexp" x="64" y="109">[#xD]</text>
+         <polygon points="51 151 58 135 170 135 177 151 170 167 58 167"></polygon>
+         <polygon points="49 149 56 133 168 133 175 149 168 165 56 165" class="regexp"></polygon>
+         <text class="regexp" x="64" y="153">[#x20-#xD7FF]</text>
+         <polygon points="51 195 58 179 186 179 193 195 186 211 58 211"></polygon>
+         <polygon points="49 193 56 177 184 177 191 193 184 209 56 209" class="regexp"></polygon>
+         <text class="regexp" x="64" y="197">[#xE000-#xFFFD]</text>
+         <polygon points="51 239 58 223 208 223 215 239 208 255 58 255"></polygon>
+         <polygon points="49 237 56 221 206 221 213 237 206 253 56 253" class="regexp"></polygon>
+         <text class="regexp" x="64" y="241">[#x10000-#x10FFFF]</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h98 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m66 0 h10 m0 0 h98 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m66 0 h10 m0 0 h98 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m126 0 h10 m0 0 h38 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m142 0 h10 m0 0 h22 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m23 -220 h-3"></svg:path>
+         <polygon points="253 17 261 13 261 21"></polygon>
+         <polygon points="253 17 245 13 245 21"></polygon></svg><xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:div class="ebnf"><xhtml:code>
+               <div><a href="#Char" title="Char">Char</a>     ::= [#x9#xA#xD#x20-#xD7FF#xE000-#xFFFD#x10000-#x10FFFF]</div></xhtml:code></xhtml:div>
+      </xhtml:p>
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">referenced by:
+         <xhtml:ul>
+            <xhtml:li><xhtml:a href="#CharacterGroupItem" title="CharacterGroupItem">CharacterGroupItem</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#CharacterRange" title="CharacterRange">CharacterRange</xhtml:a></xhtml:li>
+            <xhtml:li><xhtml:a href="#MatchCharacter" title="MatchCharacter">MatchCharacter</xhtml:a></xhtml:li>
+         </xhtml:ul>
+      </xhtml:p><xhtml:br xmlns:xhtml="http://www.w3.org/1999/xhtml" /><xhtml:hr xmlns:xhtml="http://www.w3.org/1999/xhtml" />
+      <xhtml:p xmlns:xhtml="http://www.w3.org/1999/xhtml">
+         <xhtml:table border="0" class="signature">
+            <xhtml:tr>
+               <xhtml:td style="width: 100%"> </xhtml:td>
+               <xhtml:td valign="top">
+                  <xhtml:nobr class="signature">... generated by <xhtml:a name="Railroad-Diagram-Generator" class="signature" title="https://bottlecaps.de/rr" href="https://bottlecaps.de/rr" target="_blank">RR - Railroad Diagram Generator</xhtml:a></xhtml:nobr>
+               </xhtml:td>
+               <xhtml:td><xhtml:a name="Railroad-Diagram-Generator" title="https://bottlecaps.de/rr" href="https://bottlecaps.de/rr" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+                        <g transform="scale(0.178)">
+                           <circle cx="45" cy="45" r="45" style="stroke:none; fill:#FFCC00"></circle>
+                           <circle cx="45" cy="45" r="42" style="stroke:#332900; stroke-width:2px; fill:#FFCC00"></circle>
+                           <line x1="15" y1="15" x2="75" y2="75" stroke="#332900" style="stroke-width:9px;"></line>
+                           <line x1="15" y1="75" x2="75" y2="15" stroke="#332900" style="stroke-width:9px;"></line>
+                           <text x="7" y="54" style="font-size:26px; font-family:Arial, Sans-serif; font-weight:bold; fill: #332900">R</text>
+                           <text x="64" y="54" style="font-size:26px; font-family:Arial, Sans-serif; font-weight:bold; fill: #332900">R</text>
+                        </g></svg></xhtml:a></xhtml:td>
+            </xhtml:tr>
+         </xhtml:table>
+      </xhtml:p>
+   </body>
+</html>

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "regex-runtime"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+workspace = ".."
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "linear_scaling_of_input"
+path = "benches/linear.rs"
+harness = false
+
+[dependencies]
+collections-ext = { git = "https://github.com/ncatelli/collections-ext", branch = "main" }

--- a/runtime/benches/linear.rs
+++ b/runtime/benches/linear.rs
@@ -1,0 +1,103 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use regex_runtime::*;
+
+fn pad_input_to_length_with(suffix: &str, pad_str: &str, len: usize) -> String {
+    let suffix_len = suffix.chars().count();
+    let req_padding = len - suffix_len;
+
+    if suffix_len > len {
+        "".to_string()
+    } else {
+        pad_str
+            .chars()
+            .cycle()
+            .take(req_padding)
+            .chain(suffix.chars())
+            .collect()
+    }
+}
+
+pub fn linear_input_size_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("exponential input length comparison");
+    let input = "ab";
+    let pad = "xy";
+    let prog = Instructions::default().with_opcodes(vec![
+        Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+        Opcode::Any,
+        Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+        Opcode::StartSave(InstStartSave::new(0)),
+        Opcode::Consume(InstConsume::new('a')),
+        Opcode::Consume(InstConsume::new('b')),
+        Opcode::EndSave(InstEndSave::new(0)),
+        Opcode::Match,
+    ]);
+
+    (1..10)
+        .map(|exponent| 2usize.pow(exponent))
+        .map(|input_len| (pad_input_to_length_with(input, pad, input_len), input_len))
+        .for_each(|(input, sample_size)| {
+            group.throughput(Throughput::Elements(sample_size as u64));
+            group.bench_with_input(
+                BenchmarkId::new("input length of size", sample_size),
+                &(input, sample_size),
+                |b, (input, input_size)| {
+                    let expected_res = SaveGroupSlot::complete(*input_size - 2, *input_size);
+
+                    b.iter(|| {
+                        let res = run::<1>(&prog, input);
+                        assert_eq!(
+                            Some(Some(&expected_res)),
+                            res.as_ref().map(|slots| slots.get(0))
+                        )
+                    })
+                },
+            );
+        })
+}
+
+pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
+    let mut group = c.benchmark_group("input length comparison for set matching");
+    let input = "ab";
+    let pad = "xy";
+
+    let prog = Instructions::default()
+        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Ranges(
+            vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_'],
+        ))])
+        .with_opcodes(vec![
+            Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+            Opcode::Any,
+            Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+            Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+    (1..10)
+        .map(|exponent| 2usize.pow(exponent))
+        .map(|input_len| (pad_input_to_length_with(input, pad, input_len), input_len))
+        .for_each(|(input, sample_size)| {
+            group.throughput(Throughput::Elements(sample_size as u64));
+            group.bench_with_input(
+                BenchmarkId::new("input length of size", sample_size),
+                &(input, sample_size),
+                |b, (input, input_size)| {
+                    let expected_res = [SaveGroupSlot::complete(*input_size - 2, *input_size)];
+
+                    b.iter(|| {
+                        let res = run::<1>(&prog, input);
+                        assert_eq!(Some(expected_res), res)
+                    })
+                },
+            );
+        })
+}
+
+criterion_group!(
+    benches,
+    linear_input_size_comparison,
+    linear_input_size_comparison_against_set_match
+);
+criterion_main!(benches);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,0 +1,1269 @@
+use collections_ext::set::sparse::SparseSet;
+use std::fmt::{Debug, Display};
+
+/// Represents a defined match group for a pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveGroupSlot {
+    None,
+    Complete { start: usize, end: usize },
+}
+
+impl SaveGroupSlot {
+    /// Returns a boolean representing if the savegroup slot is of the `None`
+    /// variant, signifying a match was not found.
+    pub fn is_none(&self) -> bool {
+        matches!(self, SaveGroupSlot::None)
+    }
+
+    /// Returns a boolean representing if the savegroup slot is of the
+    /// `Complete` variant, signifying a match was found.
+    pub fn is_complete(&self) -> bool {
+        !self.is_none()
+    }
+
+    /// Returns a completed save group from its constituent parts.
+    pub const fn complete(start: usize, end: usize) -> Self {
+        Self::Complete { start, end }
+    }
+}
+
+impl From<SaveGroup> for SaveGroupSlot {
+    fn from(src: SaveGroup) -> Self {
+        match src {
+            SaveGroup::None => SaveGroupSlot::None,
+
+            SaveGroup::Allocated { .. } => SaveGroupSlot::None,
+            SaveGroup::Open { .. } => SaveGroupSlot::None,
+            SaveGroup::Complete { start, end, .. } => SaveGroupSlot::Complete { start, end },
+        }
+    }
+}
+
+impl Default for SaveGroupSlot {
+    fn default() -> Self {
+        SaveGroupSlot::None
+    }
+}
+
+/// Represents a Save Group as tracked on an open thread
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SaveGroup {
+    None,
+    Allocated {
+        slot_id: usize,
+    },
+    Open {
+        slot_id: usize,
+        start: usize,
+    },
+    Complete {
+        slot_id: usize,
+        start: usize,
+        end: usize,
+    },
+}
+
+impl SaveGroup {
+    pub fn is_allocated(&self) -> bool {
+        matches!(self, Self::Allocated { .. })
+    }
+
+    pub fn allocated(slot_id: usize) -> Self {
+        Self::Allocated { slot_id }
+    }
+
+    pub fn open(slot_id: usize, start: usize) -> Self {
+        Self::Open { slot_id, start }
+    }
+
+    pub fn complete(slot_id: usize, start: usize, end: usize) -> Self {
+        Self::Complete {
+            slot_id,
+            start,
+            end,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Thread<const SG: usize> {
+    save_groups: [SaveGroup; SG],
+    inst: InstIndex,
+}
+
+impl<const SG: usize> Thread<SG> {
+    pub fn new(save_groups: [SaveGroup; SG], inst: InstIndex) -> Self {
+        Self { save_groups, inst }
+    }
+}
+
+#[derive(Debug)]
+pub struct Threads<const SG: usize> {
+    gen: SparseSet,
+    threads: Vec<Thread<SG>>,
+}
+
+impl<const SG: usize> Threads<SG> {
+    pub fn with_set_size(set_capacity: usize) -> Self {
+        let ops = SparseSet::new(set_capacity);
+        Self {
+            threads: vec![],
+            gen: ops,
+        }
+    }
+}
+
+impl<const SG: usize> Default for Threads<SG> {
+    fn default() -> Self {
+        let ops = SparseSet::new(0);
+        Self {
+            threads: vec![],
+            gen: ops,
+        }
+    }
+}
+
+#[derive(Default, Debug, PartialEq)]
+pub struct Instructions {
+    sets: Vec<CharacterSet>,
+    program: Vec<Instruction>,
+}
+
+impl Instructions {
+    #[must_use]
+    pub fn new(sets: Vec<CharacterSet>, program: Vec<Opcode>) -> Self {
+        Self {
+            sets,
+            program: program
+                .into_iter()
+                .enumerate()
+                .map(|(id, opcode)| Instruction::new(id, opcode))
+                .collect(),
+        }
+    }
+
+    pub fn with_opcodes(self, program: Vec<Opcode>) -> Self {
+        Self {
+            sets: self.sets,
+            program: program
+                .into_iter()
+                .enumerate()
+                .map(|(id, opcode)| Instruction::new(id, opcode))
+                .collect(),
+        }
+    }
+
+    pub fn with_instructions(self, program: Vec<Instruction>) -> Self {
+        Self {
+            sets: self.sets,
+            program,
+        }
+    }
+
+    pub fn with_sets(self, sets: Vec<CharacterSet>) -> Self {
+        Self {
+            sets,
+            program: self.program,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.program.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Display for Instructions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for inst in self.program.iter() {
+            writeln!(f, "{:04}: {}", inst.id, inst.opcode)?
+        }
+
+        Ok(())
+    }
+}
+
+impl std::ops::Index<InstIndex> for Instructions {
+    type Output = Opcode;
+
+    fn index(&self, index: InstIndex) -> &Self::Output {
+        let idx = index.as_usize();
+        &self.program[idx].opcode
+    }
+}
+
+impl std::ops::IndexMut<InstIndex> for Instructions {
+    fn index_mut(&mut self, index: InstIndex) -> &mut Self::Output {
+        let idx = index.as_usize();
+        &mut self.program[idx].opcode
+    }
+}
+
+impl AsRef<[Instruction]> for Instructions {
+    fn as_ref(&self) -> &[Instruction] {
+        &self.program
+    }
+}
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InstIndex(u32);
+
+impl InstIndex {
+    #[inline]
+    fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    fn as_usize(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl From<u32> for InstIndex {
+    fn from(ptr: u32) -> Self {
+        Self(ptr)
+    }
+}
+
+impl std::ops::Add<u32> for InstIndex {
+    type Output = Self;
+
+    fn add(self, rhs: u32) -> Self::Output {
+        let new_ptr = self.0 + rhs;
+
+        InstIndex::from(new_ptr)
+    }
+}
+
+impl std::ops::Add<Self> for InstIndex {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let new_ptr = self.0 + rhs.0;
+
+        InstIndex::from(new_ptr)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Instruction {
+    id: usize,
+    opcode: Opcode,
+}
+
+impl Instruction {
+    #[must_use]
+    pub fn new(id: usize, opcode: Opcode) -> Self {
+        Self { id, opcode }
+    }
+}
+
+impl Display for Instruction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:04}: {}", self.id, self.opcode)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Opcode {
+    Any,
+    Consume(InstConsume),
+    ConsumeSet(InstConsumeSet),
+    Split(InstSplit),
+    Jmp(InstJmp),
+    StartSave(InstStartSave),
+    EndSave(InstEndSave),
+    Match,
+}
+
+impl Display for Opcode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Opcode::Match => Display::fmt(&InstMatch, f),
+            Opcode::Consume(i) => Display::fmt(&i, f),
+            Opcode::ConsumeSet(i) => Display::fmt(&i, f),
+            Opcode::Split(i) => Display::fmt(&i, f),
+            Opcode::Any => Display::fmt(&InstAny::new(), f),
+            Opcode::Jmp(i) => Display::fmt(&i, f),
+            Opcode::StartSave(i) => Display::fmt(&i, f),
+            Opcode::EndSave(i) => Display::fmt(&i, f),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct InstMatch;
+
+impl Display for InstMatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Match",)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct InstAny;
+
+impl InstAny {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for InstAny {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for InstAny {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Any")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstConsume {
+    value: char,
+}
+
+impl InstConsume {
+    #[must_use]
+    pub fn new(value: char) -> Self {
+        Self { value }
+    }
+}
+
+impl Display for InstConsume {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Consume: {:?}", self.value)
+    }
+}
+
+/// Represents a type that can be used as a comparative character set.
+trait CharacterRangeSetVerifiable {
+    fn in_set(&self, value: char) -> bool;
+
+    fn not_in_set(&self, value: char) -> bool {
+        !self.in_set(value)
+    }
+}
+
+impl CharacterRangeSetVerifiable for std::ops::RangeInclusive<char> {
+    fn in_set(&self, value: char) -> bool {
+        self.contains(&value)
+    }
+}
+
+impl CharacterRangeSetVerifiable for char {
+    fn in_set(&self, value: char) -> bool {
+        *self == value
+    }
+}
+
+impl<CRSV: CharacterRangeSetVerifiable> CharacterRangeSetVerifiable for Vec<CRSV> {
+    fn in_set(&self, value: char) -> bool {
+        self.iter().any(|r| r.in_set(value))
+    }
+}
+
+/// Defines that a given type can be converted into a character set.
+pub trait CharacterSetRepresentable: Into<CharacterSet> {}
+
+/// Representing a runtime-dispatchable set of characters by associating a sets
+/// membership to a character alphabet.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CharacterSet {
+    membership: SetMembership,
+    set: CharacterAlphabet,
+}
+
+impl CharacterSet {
+    pub fn inclusive(set: CharacterAlphabet) -> Self {
+        Self {
+            membership: SetMembership::Inclusive,
+            set,
+        }
+    }
+
+    pub fn exclusive(set: CharacterAlphabet) -> Self {
+        Self {
+            membership: SetMembership::Exclusive,
+            set,
+        }
+    }
+
+    pub fn invert_membership(self) -> Self {
+        let Self { membership, set } = self;
+
+        Self {
+            membership: match membership {
+                SetMembership::Inclusive => SetMembership::Exclusive,
+                SetMembership::Exclusive => SetMembership::Inclusive,
+            },
+            set,
+        }
+    }
+}
+
+impl CharacterRangeSetVerifiable for CharacterSet {
+    fn in_set(&self, value: char) -> bool {
+        match &self.membership {
+            SetMembership::Inclusive => self.set.in_set(value),
+            SetMembership::Exclusive => self.set.not_in_set(value),
+        }
+    }
+}
+
+/// Represents a runtime dispatchable set of characters.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CharacterAlphabet {
+    /// Represents a range of values i.e. `0-9`, `a-z`, `A-Z`, etc...
+    Range(std::ops::RangeInclusive<char>),
+    /// Represents an explicitly defined set of values. i.e. `[a,b,z]`, `[1,2,7]`
+    Explicit(Vec<char>),
+    /// Represents a set of range of values i.e. `[0-9a-zA-Z]`,  etc...
+    Ranges(Vec<std::ops::RangeInclusive<char>>),
+}
+
+impl CharacterAlphabet {
+    /// Joins a group of character sets into a single `Ranges` variant character set.
+    pub fn join(sets: Vec<Self>) -> CharacterAlphabet {
+        let ranges = sets
+            .into_iter()
+            .flat_map(|set| match set {
+                CharacterAlphabet::Range(r) => vec![r],
+                CharacterAlphabet::Ranges(ranges) => ranges,
+                CharacterAlphabet::Explicit(explicit_chars) => {
+                    explicit_chars.into_iter().map(|c| c..=c).collect()
+                }
+            })
+            .collect();
+
+        CharacterAlphabet::Ranges(ranges)
+    }
+}
+
+impl CharacterRangeSetVerifiable for CharacterAlphabet {
+    fn in_set(&self, value: char) -> bool {
+        match self {
+            CharacterAlphabet::Range(r) => r.in_set(value),
+            CharacterAlphabet::Explicit(v) => v.in_set(value),
+            CharacterAlphabet::Ranges(ranges) => ranges.in_set(value),
+        }
+    }
+}
+
+/// Denotes whether a given set is inclusive or exclusive to a match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SetMembership {
+    /// States that a set is inclusive of a value, i.e. the value is a member of
+    /// the set.
+    Inclusive,
+    /// States that a set is exclusive of a value, i.e. the value is not a
+    /// member of the set.
+    Exclusive,
+}
+
+/// ConsumeSet provides richer matching patterns than the more constrained
+/// Consume or Any instructions allowing for the matching from a set of
+/// characters. This functions as a brevity tool to prevent long alternations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstConsumeSet {
+    pub idx: usize,
+}
+
+impl InstConsumeSet {
+    pub fn new(idx: usize) -> Self {
+        Self::member_of(idx)
+    }
+
+    pub fn member_of(idx: usize) -> Self {
+        Self { idx }
+    }
+}
+
+impl Display for InstConsumeSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ConsumeSet: {{{:04}}}", self.idx)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstSplit {
+    x_branch: InstIndex,
+    y_branch: InstIndex,
+}
+
+impl InstSplit {
+    #[must_use]
+    pub fn new(x: InstIndex, y: InstIndex) -> Self {
+        Self {
+            x_branch: x,
+            y_branch: y,
+        }
+    }
+}
+
+impl Display for InstSplit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Split: ({:04}), ({:04})",
+            self.x_branch.as_u32(),
+            self.y_branch.as_u32()
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstJmp {
+    next: InstIndex,
+}
+
+impl InstJmp {
+    pub fn new(next: InstIndex) -> Self {
+        Self { next }
+    }
+}
+
+impl Display for InstJmp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JumpAbs: ({:04})", self.next.as_u32())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstStartSave {
+    slot_id: usize,
+}
+
+impl InstStartSave {
+    #[must_use]
+    pub fn new(slot_id: usize) -> Self {
+        Self { slot_id }
+    }
+}
+
+impl Display for InstStartSave {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StartSave[{:04}]", self.slot_id,)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InstEndSave {
+    slot_id: usize,
+}
+
+impl InstEndSave {
+    #[must_use]
+    pub fn new(slot_id: usize) -> Self {
+        Self { slot_id }
+    }
+}
+
+impl Display for InstEndSave {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EndSave[{:04}]", self.slot_id,)
+    }
+}
+
+fn get_at(input: &str, idx: usize) -> Option<char> {
+    input[idx..].chars().next()
+}
+
+fn add_thread<const SG: usize>(
+    program: &[Instruction],
+    save_groups: &mut [SaveGroupSlot; SG],
+    mut thread_list: Threads<SG>,
+    t: Thread<SG>,
+    sp: usize,
+    input: &str,
+) -> Threads<SG> {
+    let inst_idx = t.inst;
+    let default_next_inst_idx = inst_idx + 1;
+
+    // Don't visit states we've already added.
+    let inst = match program.get(inst_idx.as_usize()) {
+        // if the thread is already defined, return.
+        Some(inst) if thread_list.gen.contains(&inst.id) => return thread_list,
+        // if it's the end of the program without a match instruction, return.
+        None => return thread_list,
+        // Otherwise add the new thread.
+        Some(inst) => {
+            thread_list.gen.insert(inst.id);
+            inst
+        }
+    };
+
+    let opcode = &inst.opcode;
+    match opcode {
+        Opcode::Split(InstSplit { x_branch, y_branch }) => {
+            let x = *x_branch;
+            let y = *y_branch;
+            thread_list = add_thread(
+                program,
+                save_groups,
+                thread_list,
+                Thread::new(t.save_groups, x),
+                sp,
+                input,
+            );
+
+            add_thread(
+                program,
+                save_groups,
+                thread_list,
+                Thread::new(t.save_groups, y),
+                sp,
+                input,
+            )
+        }
+        Opcode::Jmp(InstJmp { next }) => add_thread(
+            program,
+            save_groups,
+            thread_list,
+            Thread::new(t.save_groups, *next),
+            sp,
+            input,
+        ),
+        Opcode::StartSave(InstStartSave { slot_id }) => {
+            let mut groups = t.save_groups;
+            groups[*slot_id] = SaveGroup::Allocated { slot_id: *slot_id };
+
+            add_thread(
+                program,
+                save_groups,
+                thread_list,
+                Thread::new(groups, default_next_inst_idx),
+                sp,
+                input,
+            )
+        }
+        Opcode::EndSave(InstEndSave { slot_id }) => {
+            let closed_save = match t.save_groups.get(*slot_id) {
+                Some(SaveGroup::Open { slot_id, start }) => SaveGroup::Complete {
+                    slot_id: *slot_id,
+                    start: *start,
+                    end: sp,
+                },
+
+                // if the save group is not open, return none.
+                Some(sg) => *sg,
+                None => panic!("index out of range"),
+            };
+            let next = inst_idx + 1;
+
+            save_groups[*slot_id] = SaveGroupSlot::from(closed_save);
+            let mut thread_save_group = t.save_groups;
+            thread_save_group[*slot_id] = closed_save;
+
+            add_thread(
+                program,
+                save_groups,
+                thread_list,
+                Thread::new(thread_save_group, next),
+                sp,
+                input,
+            )
+        }
+        _ => {
+            thread_list.threads.push(t);
+            thread_list
+        }
+    }
+}
+
+/// Executes a given program against an input. If a match is found an
+/// `Optional` vector of savegroups is returned. A match occurs if all
+/// savegroup slots are marked complete and pattern match is found.
+pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[SaveGroupSlot; SG]> {
+    use core::mem::swap;
+
+    let sets = &program.sets;
+    let instructions = program.as_ref();
+
+    let input_len = input.len();
+    let program_len = instructions.len();
+
+    let mut input_idx = 0;
+    let mut current_thread_list = Threads::with_set_size(program_len);
+    let mut next_thread_list = Threads::with_set_size(program_len);
+    // a running tracker of found matches
+    let mut matches = 0;
+
+    let mut sub = [SaveGroupSlot::None; SG];
+
+    current_thread_list = add_thread(
+        instructions,
+        &mut sub,
+        current_thread_list,
+        Thread::new([SaveGroup::None; SG], InstIndex::from(0)),
+        input_idx,
+        input,
+    );
+
+    'outer: while input_idx <= input_len {
+        for thread in current_thread_list.threads.iter() {
+            let thread_save_groups = thread.save_groups;
+            let next_char = get_at(input, input_idx);
+            let inst_idx = thread.inst;
+            let default_next_inst_idx = inst_idx + 1;
+            let opcode = instructions.get(inst_idx.as_usize()).map(|i| &i.opcode);
+
+            match opcode {
+                Some(Opcode::Any) if next_char.is_none() => {
+                    break;
+                }
+                Some(Opcode::Any) => {
+                    let thread_local_save_group = thread_save_groups;
+
+                    next_thread_list = add_thread(
+                        instructions,
+                        &mut sub,
+                        next_thread_list,
+                        Thread::new(thread_local_save_group, default_next_inst_idx),
+                        input_idx + 1,
+                        input,
+                    );
+                }
+
+                Some(Opcode::Consume(InstConsume { value })) if Some(*value) == next_char => {
+                    let mut thread_local_save_group = thread_save_groups;
+                    for thr in thread_local_save_group
+                        .iter_mut()
+                        .filter(|t| t.is_allocated())
+                    {
+                        if let SaveGroup::Allocated { slot_id } = thr {
+                            *thr = SaveGroup::open(*slot_id, input_idx);
+                        }
+                    }
+
+                    next_thread_list = add_thread(
+                        instructions,
+                        &mut sub,
+                        next_thread_list,
+                        Thread::new(thread_local_save_group, default_next_inst_idx),
+                        input_idx + 1,
+                        input,
+                    );
+                }
+
+                Some(Opcode::ConsumeSet(InstConsumeSet { idx: set_idx }))
+                    if next_char.map_or(false, |c| {
+                        sets.get(*set_idx).map_or(false, |set| set.in_set(c))
+                    }) =>
+                {
+                    let mut thread_local_save_group = thread_save_groups;
+                    for thr in thread_local_save_group
+                        .iter_mut()
+                        .filter(|t| t.is_allocated())
+                    {
+                        if let SaveGroup::Allocated { slot_id } = thr {
+                            *thr = SaveGroup::open(*slot_id, input_idx);
+                        }
+                    }
+
+                    next_thread_list = add_thread(
+                        instructions,
+                        &mut sub,
+                        next_thread_list,
+                        Thread::<SG>::new(thread_local_save_group, default_next_inst_idx),
+                        input_idx + 1,
+                        input,
+                    );
+                }
+
+                Some(Opcode::Match) => {
+                    matches += 1;
+                    continue;
+                }
+                None => {
+                    break 'outer;
+                }
+                _ => continue,
+            }
+        }
+
+        input_idx += 1;
+        swap(&mut current_thread_list, &mut next_thread_list);
+        next_thread_list.threads.clear();
+        next_thread_list.gen.clear();
+
+        if current_thread_list.threads.is_empty() {
+            break 'outer;
+        }
+    }
+
+    // Signifies all savegroups are satisfied
+    let all_complete = sub.iter().all(|sg| sg.is_complete());
+    if matches > 0 && all_complete {
+        Some(sub)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_evaluate_simple_linear_match_expression() {
+        let progs = vec![
+            (
+                Some([SaveGroupSlot::complete(0, 1)]),
+                Instructions::default().with_opcodes(vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ]),
+            ),
+            (
+                None,
+                Instructions::default().with_opcodes(vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('b')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ]),
+            ),
+        ];
+
+        let input = "aab";
+
+        for (expected_res, prog) in progs {
+            let res = run::<1>(&prog, input);
+            assert_eq!(expected_res, res)
+        }
+    }
+
+    #[test]
+    fn should_evaluate_alternation_expression() {
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Split(InstSplit::new(InstIndex::from(2), InstIndex::from(4))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Jmp(InstJmp::new(InstIndex::from(5))),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+        let input_output = vec![
+            ("a", Some([SaveGroupSlot::complete(0, 1)])),
+            ("b", Some([SaveGroupSlot::complete(0, 1)])),
+            ("ab", Some([SaveGroupSlot::complete(0, 1)])),
+            ("ba", Some([SaveGroupSlot::complete(0, 1)])),
+            ("c", None),
+        ];
+
+        for (test_id, (input, expected_res)) in input_output.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((test_id, expected_res), (test_id, res))
+        }
+    }
+
+    #[test]
+    fn should_evaluate_set_match_expression() {
+        let progs = vec![
+            (
+                Some([SaveGroupSlot::complete(0, 1)]),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+            ),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(1))),
+            (
+                Some([SaveGroupSlot::complete(0, 1)]),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(3)),
+            ),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(2))),
+            (
+                Some([SaveGroupSlot::complete(0, 1)]),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(4)),
+            ),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(5))),
+            (
+                Some([SaveGroupSlot::complete(0, 1)]),
+                Opcode::ConsumeSet(InstConsumeSet::member_of(7)),
+            ),
+            (None, Opcode::ConsumeSet(InstConsumeSet::member_of(6))),
+        ];
+
+        let input = "aab";
+
+        for (test_id, (expected_res, consume_set_inst)) in progs.into_iter().enumerate() {
+            let prog = Instructions::default()
+                .with_sets(vec![
+                    CharacterSet::inclusive(CharacterAlphabet::Explicit(vec!['a', 'b'])),
+                    CharacterSet::exclusive(CharacterAlphabet::Explicit(vec!['a', 'b'])),
+                    CharacterSet::inclusive(CharacterAlphabet::Explicit(vec!['x', 'y', 'z'])),
+                    CharacterSet::exclusive(CharacterAlphabet::Explicit(vec!['x', 'y', 'z'])),
+                    CharacterSet::inclusive(CharacterAlphabet::Range('a'..='z')),
+                    CharacterSet::exclusive(CharacterAlphabet::Range('a'..='z')),
+                    CharacterSet::inclusive(CharacterAlphabet::Range('x'..='z')),
+                    CharacterSet::exclusive(CharacterAlphabet::Range('x'..='z')),
+                ])
+                .with_opcodes(vec![
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    consume_set_inst,
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ]);
+            let res = run::<1>(&prog, input);
+            assert_eq!((test_id, expected_res), (test_id, res))
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_character_class_zero_or_one_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some([SaveGroupSlot::complete(0, 1)]), "1ab"),
+            (Some([SaveGroupSlot::complete(0, 2)]), "123"),
+        ];
+
+        // `^\d\d?` | `^[0-9][0-9]?`
+        let prog = Instructions::default()
+            .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                '0'..='9',
+            ))])
+            .with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(4))),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_character_class_zero_or_more_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some([SaveGroupSlot::complete(0, 1)]), "1ab"),
+            (Some([SaveGroupSlot::complete(0, 3)]), "123"),
+        ];
+
+        // `^\d\d*` | `^[0-9][0-9]*`
+        let prog = Instructions::default()
+            .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                '0'..='9',
+            ))])
+            .with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_character_class_one_or_more_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some([SaveGroupSlot::complete(0, 1)]), "1ab"),
+            (Some([SaveGroupSlot::complete(0, 3)]), "123"),
+        ];
+
+        // `^\d+` | `^[0-9]+`
+        let prog = Instructions::default()
+            .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Range(
+                '0'..='9',
+            ))])
+            .with_opcodes(vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(5))),
+                Opcode::ConsumeSet(InstConsumeSet::new(0)),
+                Opcode::Jmp(InstJmp::new(InstIndex::from(2))),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_consecutive_diverging_match_expression() {
+        let progs = vec![
+            (
+                [SaveGroupSlot::complete(0, 2)],
+                Instructions::default().with_opcodes(vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                    Opcode::Any,
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ]),
+            ),
+            (
+                [SaveGroupSlot::complete(1, 3)],
+                Instructions::default().with_opcodes(vec![
+                    Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                    Opcode::Any,
+                    Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                    Opcode::StartSave(InstStartSave::new(0)),
+                    Opcode::Consume(InstConsume::new('a')),
+                    Opcode::Consume(InstConsume::new('b')),
+                    Opcode::EndSave(InstEndSave::new(0)),
+                    Opcode::Match,
+                ]),
+            ),
+        ];
+
+        let input = "aab";
+
+        for (test_num, (expected_res, prog)) in progs.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((test_num, Some(expected_res)), (test_num, res))
+        }
+    }
+
+    #[test]
+    fn should_evaluate_multiple_save_groups_expression() {
+        // (aa)(b)
+        let (expected_res, prog) = (
+            [SaveGroupSlot::complete(0, 2), SaveGroupSlot::complete(2, 3)],
+            Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::StartSave(InstStartSave::new(1)),
+                Opcode::Consume(InstConsume::new('b')),
+                Opcode::EndSave(InstEndSave::new(1)),
+                Opcode::Match,
+            ]),
+        );
+
+        let input = "aab";
+
+        let res = run::<2>(&prog, input);
+        assert_eq!(Some(expected_res), res)
+    }
+
+    #[test]
+    fn should_evaluate_eager_match_zero_or_one_expression() {
+        let tests = vec![
+            ([SaveGroupSlot::complete(0, 2)], "aab"),
+            ([SaveGroupSlot::complete(0, 3)], "aaab"),
+            ([SaveGroupSlot::complete(0, 3)], "aaaab"),
+        ];
+
+        // `^(aaa?)`
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(5))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, Some(expected_res)), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_lazy_match_zero_or_one_expression() {
+        let tests = vec![
+            (None, "aab"),
+            (Some([SaveGroupSlot::complete(0, 3)]), "aaab"),
+            (Some([SaveGroupSlot::complete(0, 4)]), "aaaab"),
+        ];
+
+        // `^(aaa??)`
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(5), InstIndex::from(4))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, expected_res), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_match_exact_quantifier_expression() {
+        let tests = vec![
+            ([SaveGroupSlot::complete(0, 2)], "aab"),
+            ([SaveGroupSlot::complete(0, 2)], "aaab"),
+        ];
+
+        let prog = Instructions::new(
+            vec![],
+            vec![
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ],
+        );
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, Some(expected_res)), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_match_atleast_quantifier_expression() {
+        let tests = vec![
+            ([SaveGroupSlot::complete(0, 2)], "aab"),
+            ([SaveGroupSlot::complete(0, 3)], "aaab"),
+        ];
+
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(6))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Jmp(InstJmp::new(InstIndex::from(3))),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, Some(expected_res)), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_eager_match_between_quantifier_expression() {
+        let tests = vec![
+            ([SaveGroupSlot::complete(0, 2)], "aab"),
+            ([SaveGroupSlot::complete(0, 3)], "aaab"),
+            ([SaveGroupSlot::complete(0, 4)], "aaaab"),
+        ];
+
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(4), InstIndex::from(5))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(7))),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+            Opcode::Match,
+        ]);
+
+        for (case_id, (expected_res, input)) in tests.into_iter().enumerate() {
+            let res = run::<1>(&prog, input);
+            assert_eq!((case_id, Some(expected_res)), (case_id, res));
+        }
+    }
+
+    #[test]
+    fn should_evaluate_nested_group_expression() {
+        // ^(a(b))
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::StartSave(InstStartSave::new(1)),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::EndSave(InstEndSave::new(1)),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        let res = run::<2>(&prog, "ab");
+        assert_eq!(
+            Some([SaveGroupSlot::complete(0, 2), SaveGroupSlot::complete(1, 2),]),
+            res
+        );
+    }
+
+    #[test]
+    fn should_evaluate_nested_quantified_group_expression() {
+        // ^(a(b){2,})
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::StartSave(InstStartSave::new(1)),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Split(InstSplit::new(InstIndex::from(6), InstIndex::from(8))),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Jmp(InstJmp::new(InstIndex::from(5))),
+            Opcode::EndSave(InstEndSave::new(1)),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ]);
+
+        let res = run::<2>(&prog, "abbb");
+        assert_eq!(
+            Some([SaveGroupSlot::complete(0, 4), SaveGroupSlot::complete(1, 4),]),
+            res
+        );
+    }
+
+    #[test]
+    fn should_retain_a_fixed_opcode_size() {
+        use core::mem::size_of;
+
+        assert_eq!(16, size_of::<Opcode>())
+    }
+
+    #[test]
+    fn should_print_test_instructions() {
+        let prog = Instructions::default().with_opcodes(vec![
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::Match,
+            Opcode::Match,
+        ]);
+
+        assert_eq!(
+            "0000: Consume: 'a'
+0001: Consume: 'b'
+0002: Match
+0003: Match\n",
+            prog.to_string()
+        )
+    }
+}


### PR DESCRIPTION
This PR moves the relex subcrates for the regex compiler and runtime to their own project as it's grown legs and is something i'ld like to maintain externally.