### PR TITLE
Fix usage binary name in the re example

### DIFF
--- a/compiler/examples/re/main.rs
+++ b/compiler/examples/re/main.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead};
 
 use regex_compiler::{compile, parse};
 
-const USAGE: &str = "grep-analog PATTERN [FILE]";
+const USAGE: &str = "re PATTERN [FILE]";
 
 fn main() -> Result<(), String> {
     let (debug, args) = std::env::args()


### PR DESCRIPTION
# Introduction
Rename the `USAGE` command name in the `re` binary in `regex-compiler` to correspond to the binary name.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
