### PR TITLE
slice on the char boundary

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
 	"extensions": [
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor",
-		"matklad.rust-analyzer",
+		"rust-lang.rust-analyzer",
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -808,7 +808,9 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
             }
         }
 
-        input_idx += get_at_char_boundary(input, input_idx).map_or(0, |c| c.len_utf8());
+        let bytes_to_next_char_boundary =
+            get_at_char_boundary(input, input_idx).map_or(0, |c| c.len_utf8());
+        input_idx += bytes_to_next_char_boundary;
         swap(&mut current_thread_list, &mut next_thread_list);
         next_thread_list.threads.clear();
         next_thread_list.gen.clear();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -573,8 +573,17 @@ impl Display for InstEndSave {
     }
 }
 
-fn get_at(input: &str, idx: usize) -> Option<char> {
-    input[..].chars().nth(idx)
+fn get_at_boundary(input: &str, idx: usize) -> Option<char> {
+    let bottom_boundary = if idx >= 3 { idx - 3 } else { 0 };
+
+    for backtracking_idx in (bottom_boundary..=idx).rev() {
+        match input.get(backtracking_idx..) {
+            Some(c) => return c.chars().next(),
+            None => continue,
+        };
+    }
+
+    None
 }
 
 fn add_thread<const SG: usize>(
@@ -711,7 +720,7 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
     'outer: while input_idx <= input_len {
         for thread in current_thread_list.threads.iter() {
             let thread_save_groups = thread.save_groups;
-            let next_char = get_at(input, input_idx);
+            let next_char = get_at_boundary(input, input_idx);
             let inst_idx = thread.inst;
             let default_next_inst_idx = inst_idx + 1;
             let opcode = instructions.get(inst_idx.as_usize()).map(|i| &i.opcode);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -574,7 +574,7 @@ impl Display for InstEndSave {
 }
 
 /// This attempts to fetch a valid unicode character at an index. If the index
-/// falls within a unicode character boundary, it will back track up to 4 bytes
+/// falls within a unicode character boundary, it will back track up to 3 bytes
 /// to look for the boundary.
 fn get_at_char_boundary(input: &str, idx: usize) -> Option<char> {
     match input.get(idx..) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -581,9 +581,8 @@ fn get_at_char_boundary(input: &str, idx: usize) -> Option<char> {
         Some(c) => c.chars().next(),
         None => {
             let bottom_boundary = idx.saturating_sub(3);
-            let top_boundary = idx.saturating_sub(1);
 
-            for backtracking_idx in (bottom_boundary..=top_boundary).rev() {
+            for backtracking_idx in (bottom_boundary..idx).rev() {
                 match input.get(backtracking_idx..) {
                     Some(c) => return c.chars().next(),
                     None => continue,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -588,6 +588,7 @@ fn get_at_char_boundary(input: &str, idx: usize) -> Option<char> {
                     None => continue,
                 }
             }
+
             None
         }
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -574,7 +574,7 @@ impl Display for InstEndSave {
 }
 
 fn get_at(input: &str, idx: usize) -> Option<char> {
-    input[idx..].chars().next()
+    input[..].chars().nth(idx)
 }
 
 fn add_thread<const SG: usize>(


### PR DESCRIPTION
# Introduction
This PR address the issue where slicing over a non-ascii unicode character will cause a panic by causing an explicit check for unicode character boundaries. If the index lands within a boundary the slice backtracks to the start of the boundary.

# Linked Issues
resolves #4 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
