### PR TITLE
Handle unicode processing at the input side

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -583,7 +583,6 @@ fn add_thread<const SG: usize>(
     mut thread_list: Threads<SG>,
     t: Thread<SG>,
     sp: usize,
-    input: &str,
 ) -> Threads<SG> {
     let inst_idx = t.inst;
     let default_next_inst_idx = inst_idx + 1;
@@ -612,7 +611,6 @@ fn add_thread<const SG: usize>(
                 thread_list,
                 Thread::new(t.save_groups, x),
                 sp,
-                input,
             );
 
             add_thread(
@@ -621,7 +619,6 @@ fn add_thread<const SG: usize>(
                 thread_list,
                 Thread::new(t.save_groups, y),
                 sp,
-                input,
             )
         }
         Opcode::Jmp(InstJmp { next }) => add_thread(
@@ -630,7 +627,6 @@ fn add_thread<const SG: usize>(
             thread_list,
             Thread::new(t.save_groups, *next),
             sp,
-            input,
         ),
         Opcode::StartSave(InstStartSave { slot_id }) => {
             let mut groups = t.save_groups;
@@ -642,7 +638,6 @@ fn add_thread<const SG: usize>(
                 thread_list,
                 Thread::new(groups, default_next_inst_idx),
                 sp,
-                input,
             )
         }
         Opcode::EndSave(InstEndSave { slot_id }) => {
@@ -669,7 +664,6 @@ fn add_thread<const SG: usize>(
                 thread_list,
                 Thread::new(thread_save_group, next),
                 sp,
-                input,
             )
         }
         _ => {
@@ -705,7 +699,6 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
         current_thread_list,
         Thread::new([SaveGroup::None; SG], InstIndex::from(0)),
         input_idx,
-        input,
     );
 
     'outer: while input_idx <= input_len {
@@ -730,7 +723,6 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
                         next_thread_list,
                         Thread::new(thread_local_save_group, default_next_inst_idx),
                         input_idx + next_char_size_in_bytes,
-                        input,
                     );
                 }
 
@@ -751,7 +743,6 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
                         next_thread_list,
                         Thread::new(thread_local_save_group, default_next_inst_idx),
                         input_idx + next_char_size_in_bytes,
-                        input,
                     );
                 }
 
@@ -776,7 +767,6 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
                         next_thread_list,
                         Thread::<SG>::new(thread_local_save_group, default_next_inst_idx),
                         input_idx + next_char_size_in_bytes,
-                        input,
                     );
                 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -573,25 +573,8 @@ impl Display for InstEndSave {
     }
 }
 
-/// This attempts to fetch a valid unicode character at an index. If the index
-/// falls within a unicode character boundary, it will back track up to 3 bytes
-/// to look for the boundary.
 fn get_at_char_boundary(input: &str, idx: usize) -> Option<char> {
-    match input.get(idx..) {
-        Some(c) => c.chars().next(),
-        None => {
-            let bottom_boundary = idx.saturating_sub(3);
-
-            for backtracking_idx in (bottom_boundary..idx).rev() {
-                match input.get(backtracking_idx..) {
-                    Some(c) => return c.chars().next(),
-                    None => continue,
-                }
-            }
-
-            None
-        }
-    }
+    input.get(idx..).and_then(|sub_str| sub_str.chars().next())
 }
 
 fn add_thread<const SG: usize>(


### PR DESCRIPTION
# Introduction
This PR undoes the changes in #6 by handling unicode processing solely at the input side. This was handled previously, making the backtracking redundant. This PR also introduces a custom Iterator to better encapsulate the character walk, which is a linear traversal and best represented as an iterator. The custom implementation is to provide byte position tracking.

# Linked Issues
resolves #4 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
