### PR TITLE
Implement best effort fast-forwarding to first possible match

### DIFF
--- a/runtime/benches/linear.rs
+++ b/runtime/benches/linear.rs
@@ -55,6 +55,46 @@ pub fn linear_input_size_comparison(c: &mut Criterion) {
         })
 }
 
+pub fn linear_input_size_comparison_with_fast_forward(c: &mut Criterion) {
+    let mut group = c.benchmark_group("exponential input length comparison with fast-forward");
+    let input = "ab";
+    let pad = "xy";
+    let prog = Instructions::default()
+        .with_opcodes(vec![
+            Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+            Opcode::Any,
+            Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::Consume(InstConsume::new('a')),
+            Opcode::Consume(InstConsume::new('b')),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ])
+        .with_fast_forward(FastForward::Char('a'));
+
+    (1..10)
+        .map(|exponent| 2usize.pow(exponent))
+        .map(|input_len| (pad_input_to_length_with(input, pad, input_len), input_len))
+        .for_each(|(input, sample_size)| {
+            group.throughput(Throughput::Elements(sample_size as u64));
+            group.bench_with_input(
+                BenchmarkId::new("input length of size", sample_size),
+                &(input, sample_size),
+                |b, (input, input_size)| {
+                    let expected_res = SaveGroupSlot::complete(*input_size - 2, *input_size);
+
+                    b.iter(|| {
+                        let res = run::<1>(&prog, input);
+                        assert_eq!(
+                            Some(Some(&expected_res)),
+                            res.as_ref().map(|slots| slots.get(0))
+                        )
+                    })
+                },
+            );
+        })
+}
+
 pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
     let mut group = c.benchmark_group("input length comparison for set matching");
     let input = "ab";
@@ -95,9 +135,54 @@ pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
         })
 }
 
+pub fn linear_input_size_comparison_against_set_match_with_fast_forward(c: &mut Criterion) {
+    let mut group = c.benchmark_group("input length comparison for set matching with fast-forward");
+    let input = "ab";
+    let pad = "xy";
+
+    let prog = Instructions::default()
+        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Ranges(
+            vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_'],
+        ))])
+        .with_opcodes(vec![
+            Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+            Opcode::Any,
+            Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+            Opcode::StartSave(InstStartSave::new(0)),
+            Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+            Opcode::ConsumeSet(InstConsumeSet::member_of(0)),
+            Opcode::EndSave(InstEndSave::new(0)),
+            Opcode::Match,
+        ])
+        .with_fast_forward(FastForward::Set(CharacterSet::inclusive(
+            CharacterAlphabet::Ranges(vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_']),
+        )));
+
+    (1..10)
+        .map(|exponent| 2usize.pow(exponent))
+        .map(|input_len| (pad_input_to_length_with(input, pad, input_len), input_len))
+        .for_each(|(input, sample_size)| {
+            group.throughput(Throughput::Elements(sample_size as u64));
+            group.bench_with_input(
+                BenchmarkId::new("input length of size", sample_size),
+                &(input, sample_size),
+                |b, (input, input_size)| {
+                    let expected_res = [SaveGroupSlot::complete(*input_size - 2, *input_size)];
+
+                    b.iter(|| {
+                        let res = run::<1>(&prog, input);
+                        assert_eq!(Some(expected_res), res)
+                    })
+                },
+            );
+        })
+}
+
 criterion_group!(
     benches,
     linear_input_size_comparison,
-    linear_input_size_comparison_against_set_match
+    linear_input_size_comparison_with_fast_forward,
+    linear_input_size_comparison_against_set_match,
+    linear_input_size_comparison_against_set_match_with_fast_forward
 );
 criterion_main!(benches);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -307,6 +307,24 @@ pub enum Opcode {
     Match,
 }
 
+impl Opcode {
+    /// Returns true if the opcode represents an input consuming operations.
+    #[allow(unused)]
+    pub fn is_consuming(&self) -> bool {
+        matches!(
+            self,
+            Opcode::Any | Opcode::Consume(_) | Opcode::ConsumeSet(_)
+        )
+    }
+
+    /// Returns true if the opcode represents an input consuming operations
+    /// that represents an explicit value or alphabet.
+    #[allow(unused)]
+    pub fn is_explicit_consuming(&self) -> bool {
+        matches!(self, Opcode::Consume(_) | Opcode::ConsumeSet(_))
+    }
+}
+
 impl Display for Opcode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -354,7 +372,7 @@ impl Display for InstAny {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct InstConsume {
-    value: char,
+    pub value: char,
 }
 
 impl InstConsume {


### PR DESCRIPTION
# Introduction
This PR introduces fast-forwarding through input, by defining a few set chases where the compiler can guarantee that any characters before a single character or set of characters _MUST_ can safely be skipped.

In cases of long strings with unanchored input this can yield significant performance improvements.

## Other changes
- Remove `CharsWithBytePosition` wrapper iterator in favor of an enumerated `char` iterator.
- Regroups the termination cases for a pattern evaluation.

# Linked Issues
resolves #8 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
