### PR TITLE
Fixes unanchored matches not preserving first match

### DIFF
--- a/runtime/benches/linear.rs
+++ b/runtime/benches/linear.rs
@@ -99,11 +99,15 @@ pub fn linear_input_size_comparison_against_set_match(c: &mut Criterion) {
     let mut group = c.benchmark_group("input length comparison for set matching");
     let input = "ab";
     let pad = "xy";
+    let inclusive_set = CharacterSet::inclusive(CharacterAlphabet::Ranges(vec![
+        'a'..='w',
+        'A'..='W',
+        '0'..='9',
+        '_'..='_',
+    ]));
 
     let prog = Instructions::default()
-        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Ranges(
-            vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_'],
-        ))])
+        .with_sets(vec![inclusive_set])
         .with_opcodes(vec![
             Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
             Opcode::Any,
@@ -139,11 +143,15 @@ pub fn linear_input_size_comparison_against_set_match_with_fast_forward(c: &mut 
     let mut group = c.benchmark_group("input length comparison for set matching with fast-forward");
     let input = "ab";
     let pad = "xy";
+    let inclusive_set = CharacterSet::inclusive(CharacterAlphabet::Ranges(vec![
+        'a'..='w',
+        'A'..='W',
+        '0'..='9',
+        '_'..='_',
+    ]));
 
     let prog = Instructions::default()
-        .with_sets(vec![CharacterSet::inclusive(CharacterAlphabet::Ranges(
-            vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_'],
-        ))])
+        .with_sets(vec![inclusive_set.clone()])
         .with_opcodes(vec![
             Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
             Opcode::Any,
@@ -154,9 +162,7 @@ pub fn linear_input_size_comparison_against_set_match_with_fast_forward(c: &mut 
             Opcode::EndSave(InstEndSave::new(0)),
             Opcode::Match,
         ])
-        .with_fast_forward(FastForward::Set(CharacterSet::inclusive(
-            CharacterAlphabet::Ranges(vec!['a'..='z', 'A'..='Z', '0'..='9', '_'..='_']),
-        )));
+        .with_fast_forward(FastForward::Set(inclusive_set));
 
     (1..10)
         .map(|exponent| 2usize.pow(exponent))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1153,6 +1153,28 @@ mod tests {
     }
 
     #[test]
+    fn should_match_first_match() {
+        let (save_group, prog) = (
+            [SaveGroupSlot::complete(0, 2)],
+            Instructions::default().with_opcodes(vec![
+                Opcode::Split(InstSplit::new(InstIndex::from(3), InstIndex::from(1))),
+                Opcode::Any,
+                Opcode::Jmp(InstJmp::new(InstIndex::from(0))),
+                Opcode::StartSave(InstStartSave::new(0)),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::Consume(InstConsume::new('a')),
+                Opcode::EndSave(InstEndSave::new(0)),
+                Opcode::Match,
+            ]),
+        );
+
+        let input = "aaaab";
+
+        let res = run::<1>(&prog, input);
+        assert_eq!(Some(save_group), res)
+    }
+
+    #[test]
     fn should_evaluate_multiple_save_groups_expression() {
         // (aa)(b)
         let (expected_res, prog) = (

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -759,7 +759,6 @@ fn add_thread<const SG: usize>(
                 Some(sg) => *sg,
                 None => panic!("index out of range"),
             };
-            let next = inst_idx + 1;
 
             save_groups[*slot_id] = SaveGroupSlot::from(closed_save);
             let mut thread_save_group = t.save_groups;
@@ -769,7 +768,7 @@ fn add_thread<const SG: usize>(
                 program,
                 save_groups,
                 thread_list,
-                Thread::new(thread_save_group, next),
+                Thread::new(thread_save_group, default_next_inst_idx),
                 sp,
             )
         }


### PR DESCRIPTION
# Introduction
This PR fixes an issue where unanchored matches preferred local thread state matches to an already completed valid match.

An example of where this is a problem would be the following


pattern -> input:
- `(aa)` -> `aaab`

Prior to this PR, the match would return a match range of `1..3` as the thread would consume until the last possible match. Instead, the returned match should be `0..2` to cover the first equivalent match state.

This PR will not impact quantified matches as it will update an already completed match if their start pointers match.

# Linked Issues
resolves #14 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
