### PR TITLE
Allow more accurate windowing

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -865,7 +865,7 @@ fn add_thread<const SG: usize>(
     };
 
     let opcode = &inst.opcode;
-    let [lookback, current_char, _lookahead] = window;
+    let [lookback, current_char, lookahead] = window;
     match opcode {
         Opcode::Split(InstSplit { x_branch, y_branch }) => {
             let x = *x_branch;
@@ -1000,7 +1000,8 @@ fn add_thread<const SG: usize>(
         Opcode::Epsilon(InstEpsilon {
             cond: EpsilonCond::EndOfString,
         }) => {
-            let end_of_input = current_char.is_none();
+            let end_of_input =
+                current_char.is_none() || (current_char == Some('\n') && lookahead.is_none());
 
             if end_of_input {
                 add_thread(
@@ -1715,6 +1716,8 @@ mod tests {
             (None, "baaa "),
             (Some([SaveGroupSlot::complete(1, 3)]), "baa"),
             (Some([SaveGroupSlot::complete(2, 4)]), "baaa"),
+            // match on trailing newline
+            (Some([SaveGroupSlot::complete(2, 4)]), "baaa\n"),
         ];
 
         // (aa$)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1056,21 +1056,16 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
     let mut sub = [SaveGroupSlot::None; SG];
 
     // input and eoi tracker.
-    let mut done = false;
-    let mut current_window = match input_iter.next() {
+    let (mut done, mut current_window) = match input_iter.next() {
         Some((idx, window)) => {
             let lookback = window.previous();
-            // safe to assume we can unwrap this given Some is returned if next is some.
-            let next = window.current().unwrap();
+            let current = window.current();
             let lookahead = window.next();
 
             input_idx = idx;
-            [lookback, Some(next), lookahead]
+            (false, [lookback, current, lookahead])
         }
-        None => {
-            done = true;
-            [None, None, None]
-        }
+        None => (true, [None, None, None]),
     };
 
     // add the initial thread
@@ -1089,11 +1084,10 @@ pub fn run<const SG: usize>(program: &Instructions, input: &str) -> Option<[Save
         let (next_input_idx, next_window) = match input_iter.next() {
             Some((idx, window)) => {
                 let lookback = window.previous();
-                // safe to assume we can unwrap this given Some is returned if next is some.
-                let next = window.current().unwrap();
+                let current = window.current();
                 let lookahead = window.next();
 
-                (idx, [lookback, Some(next), lookahead])
+                (idx, [lookback, current, lookahead])
             }
             None => (input_idx + 1, [None, None, None]),
         };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -865,7 +865,7 @@ fn add_thread<const SG: usize>(
     };
 
     let opcode = &inst.opcode;
-    let [lookback, current_char, lookahead] = window;
+    let [lookback, current_char, _lookahead] = window;
     match opcode {
         Opcode::Split(InstSplit { x_branch, y_branch }) => {
             let x = *x_branch;


### PR DESCRIPTION
# Introduction
This PR introduces more accurate windowing, ensuring that each thread always has a consistently sized window, providing 1 lookahead and 1 lookback character.
 
# Linked Issues

# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
