### PR TITLE
Implement start of string anchors

### DIFF
--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -987,4 +987,37 @@ mod tests {
             parse(&input)
         )
     }
+
+    #[test]
+    fn should_parse_capture_start_of_string_anchor() {
+        use ast::*;
+
+        let pattern = "((?:\\Aa)|(?:b))";
+        let input = pattern.chars().enumerate().collect::<Vec<(usize, char)>>();
+
+        assert_eq!(
+            Ok(Regex::Unanchored(Expression(vec![SubExpression(vec![
+                SubExpressionItem::Group(Group::Capturing {
+                    expression: Expression(vec![
+                        SubExpression(vec![SubExpressionItem::Group(Group::NonCapturing {
+                            expression: Expression(vec![SubExpression(vec![
+                                SubExpressionItem::Anchor(Anchor::StartOfStringOnly),
+                                SubExpressionItem::Match(Match::WithoutQuantifier {
+                                    item: MatchItem::MatchCharacter(MatchCharacter(Char('a')))
+                                })
+                            ])]),
+                        }),]),
+                        SubExpression(vec![SubExpressionItem::Group(Group::NonCapturing {
+                            expression: Expression(vec![SubExpression(vec![
+                                SubExpressionItem::Match(Match::WithoutQuantifier {
+                                    item: MatchItem::MatchCharacter(MatchCharacter(Char('b')))
+                                })
+                            ])]),
+                        })])
+                    ])
+                }),
+            ])]))),
+            parse(&input)
+        )
+    }
 }


### PR DESCRIPTION
# Introduction
This PR Implements `StartOfStringOnly` anchors only allowing patterns like `((?:\Aa)|(?:b))`
# Linked Issues
#3 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
