### PR TITLE
Allow passing of str to parse

### DIFF
--- a/compiler/benches/linear.rs
+++ b/compiler/benches/linear.rs
@@ -24,12 +24,11 @@ pub fn exponential_input_size_comparison(c: &mut Criterion) {
     (1..10)
         .map(|exponent| 2usize.pow(exponent))
         .map(|input_len| (pad_input_to_length_with("^", "", pad, input_len), input_len))
-        .map(|(input, len)| (input.chars().enumerate().collect::<Vec<_>>(), len))
         .for_each(|(input, sample_size)| {
             group.throughput(Throughput::Elements(sample_size as u64));
             group.bench_with_input(
                 BenchmarkId::new("pattern input length of size", sample_size),
-                &input,
+                input.as_str(),
                 |b, input| {
                     b.iter(|| {
                         let res = parse(input).map(compile);

--- a/compiler/examples/re/main.rs
+++ b/compiler/examples/re/main.rs
@@ -20,13 +20,12 @@ fn main() -> Result<(), String> {
     let (pattern, input) = match arg_len {
         1 => args
             .get(0)
-            .map(|pattern| (pattern, io::stdin()))
+            .map(|pattern| (pattern.as_str(), io::stdin()))
             .ok_or_else(|| USAGE.to_string()),
         _ => Err(USAGE.to_string()),
     }?;
 
-    let pattern_input: Vec<(usize, char)> = pattern.chars().enumerate().collect();
-    let program = parse(&pattern_input)
+    let program = parse(pattern)
         .map_err(|e| format!("{:?}", e))
         .and_then(compile)?;
 

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -15,13 +15,12 @@
 //! // Matches are exposed as `SaveGroupSlots`
 //! use regex_runtime::SaveGroupSlot;
 //!
-//! // All patterns must be passed as an enumerated character stream. This can be
-//! // any standard regex pattern.
-//! let pattern: Vec<(usize, char)> = "(ll)".chars().enumerate().collect();
+//! // A standard regex pattern to be parsed.
+//! let pattern = "(ll)";
 //!
 //! // Using the above `compile` and `parse` methods, the regular expresion is
 //! // parsed into an evaluatable program.
-//! let program = parse(&pattern)
+//! let program = parse(pattern)
 //!     .map_err(|e| format!("{:?}", e))
 //!     .and_then(compile).expect("failed to parser or compile");
 //!

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -18,12 +18,16 @@ impl std::fmt::Debug for ParseErr {
     }
 }
 
-pub fn parse(input: &str) -> Result<ast::Regex, ParseErr> {
-    let input: Vec<(usize, char)> = input.chars().enumerate().collect();
-    parse_enumarated_array(&input)
+/// Accepts an input representing a regex pattern, attempting to parse it into
+/// a regex AST.
+pub fn parse<S: AsRef<str>>(input: S) -> Result<ast::Regex, ParseErr> {
+    let input: Vec<(usize, char)> = input.as_ref().chars().enumerate().collect();
+    parse_enumarated_slice(&input)
 }
 
-pub fn parse_enumarated_array(input: &[(usize, char)]) -> Result<ast::Regex, ParseErr> {
+/// Accepts an enumerated slice of characters from a given input representing a
+/// regex pattern, attempting to parse it into an AST.
+pub fn parse_enumarated_slice(input: &[(usize, char)]) -> Result<ast::Regex, ParseErr> {
     regex()
         .parse(input)
         .map_err(|err| ParseErr::Undefined(format!("unspecified parse error occured: {}", err)))

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -18,7 +18,12 @@ impl std::fmt::Debug for ParseErr {
     }
 }
 
-pub fn parse(input: &[(usize, char)]) -> Result<ast::Regex, ParseErr> {
+pub fn parse(input: &str) -> Result<ast::Regex, ParseErr> {
+    let input: Vec<(usize, char)> = input.chars().enumerate().collect();
+    parse_enumarated_array(&input)
+}
+
+pub fn parse_enumarated_array(input: &[(usize, char)]) -> Result<ast::Regex, ParseErr> {
     regex()
         .parse(input)
         .map_err(|err| ParseErr::Undefined(format!("unspecified parse error occured: {}", err)))
@@ -492,11 +497,10 @@ mod tests {
             // A recursive grouping
             "the ((red|blue) pill)",
         ]
-        .into_iter()
-        .map(|input| input.chars().enumerate().collect::<Vec<(usize, char)>>());
+        .into_iter();
 
         for input in inputs {
-            let parse_result = parse(&input);
+            let parse_result = parse(input);
             assert!(parse_result.is_ok())
         }
     }
@@ -504,7 +508,6 @@ mod tests {
     #[test]
     fn should_parse_compound_match() {
         use ast::*;
-        let input = "ab".chars().enumerate().collect::<Vec<(usize, char)>>();
 
         assert_eq!(
             Ok(Regex::Unanchored(Expression(vec![SubExpression(vec![
@@ -515,14 +518,13 @@ mod tests {
                     item: MatchItem::MatchCharacter(MatchCharacter(Char('b')))
                 }),
             ])]))),
-            parse(&input)
+            parse("ab")
         )
     }
 
     #[test]
     fn should_parse_anchored_match() {
         use ast::*;
-        let input = "^ab".chars().enumerate().collect::<Vec<(usize, char)>>();
 
         assert_eq!(
             Ok(Regex::StartOfStringAnchored(Expression(vec![
@@ -535,14 +537,13 @@ mod tests {
                     }),
                 ])
             ]))),
-            parse(&input)
+            parse("^ab")
         )
     }
 
     #[test]
     fn should_parse_alternation() {
         use ast::*;
-        let input = "^a|b".chars().enumerate().collect::<Vec<(usize, char)>>();
 
         assert_eq!(
             Ok(Regex::StartOfStringAnchored(Expression(vec![
@@ -553,7 +554,7 @@ mod tests {
                     item: MatchItem::MatchCharacter(MatchCharacter(Char('b')))
                 }),])
             ]))),
-            parse(&input)
+            parse("^a|b")
         )
     }
 
@@ -576,8 +577,6 @@ mod tests {
         ];
 
         for (expected_quantifier, input) in inputs {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
             assert_eq!(
                 Ok(Regex::StartOfStringAnchored(Expression(vec![
                     SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
@@ -585,7 +584,7 @@ mod tests {
                         quantifier: Quantifier::Eager(expected_quantifier),
                     })])
                 ]))),
-                parse(&input)
+                parse(input)
             )
         }
 
@@ -593,8 +592,6 @@ mod tests {
         let inputs = vec![(QuantifierType::MatchExactRange(Integer(2)), "^a{2}")];
 
         for (expected_quantifier, input) in inputs {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
             assert_eq!(
                 Ok(Regex::StartOfStringAnchored(Expression(vec![
                     SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
@@ -602,7 +599,7 @@ mod tests {
                         quantifier: Quantifier::Eager(expected_quantifier),
                     })])
                 ]))),
-                parse(&input)
+                parse(input)
             )
         }
     }
@@ -626,8 +623,6 @@ mod tests {
         ];
 
         for (expected_quantifier, input) in inputs {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
             assert_eq!(
                 Ok(Regex::StartOfStringAnchored(Expression(vec![
                     SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
@@ -635,7 +630,7 @@ mod tests {
                         quantifier: Quantifier::Lazy(expected_quantifier),
                     })])
                 ]))),
-                parse(&input)
+                parse(input)
             )
         }
 
@@ -643,8 +638,6 @@ mod tests {
         let inputs = vec![(QuantifierType::MatchExactRange(Integer(2)), "^a{2}?")];
 
         for (expected_quantifier, input) in inputs {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
             assert_eq!(
                 Ok(Regex::StartOfStringAnchored(Expression(vec![
                     SubExpression(vec![SubExpressionItem::Match(Match::WithQuantifier {
@@ -652,7 +645,7 @@ mod tests {
                         quantifier: Quantifier::Lazy(expected_quantifier),
                     })])
                 ]))),
-                parse(&input)
+                parse(input)
             )
         }
     }
@@ -723,9 +716,7 @@ mod tests {
         ];
 
         for (test_id, (input, class)) in input_output.into_iter().enumerate() {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
-            let res = parse(&input);
+            let res = parse(input);
             assert_eq!(
                 (
                     test_id,
@@ -773,9 +764,7 @@ mod tests {
         ];
 
         for (test_id, (input, output)) in input_output.into_iter().enumerate() {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
-            let res = parse(&input);
+            let res = parse(input);
             assert_eq!(
                 (
                     test_id,
@@ -808,9 +797,7 @@ mod tests {
         ];
 
         for (test_id, (input, quantifier_ty)) in input_output.into_iter().enumerate() {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
-            let res = parse(&input);
+            let res = parse(input);
             assert_eq!(
                 (
                     test_id,
@@ -927,9 +914,7 @@ mod tests {
         ];
 
         for (test_id, (input, expected_regex_ast)) in input_output.into_iter().enumerate() {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
-            let res = parse(&input);
+            let res = parse(input);
             assert_eq!((test_id, Ok(expected_regex_ast)), (test_id, res))
         }
 
@@ -950,9 +935,7 @@ mod tests {
         ];
 
         for (test_id, (input, quantifier_ty)) in input_output.into_iter().enumerate() {
-            let input = input.chars().enumerate().collect::<Vec<(usize, char)>>();
-
-            let res = parse(&input);
+            let res = parse(input);
             assert_eq!(
                 (
                     test_id,
@@ -976,7 +959,6 @@ mod tests {
     #[test]
     fn should_parse_any_match() {
         use ast::*;
-        let input = ".".chars().enumerate().collect::<Vec<(usize, char)>>();
 
         assert_eq!(
             Ok(Regex::Unanchored(Expression(vec![SubExpression(vec![
@@ -984,16 +966,13 @@ mod tests {
                     item: MatchItem::MatchAnyCharacter
                 }),
             ])]))),
-            parse(&input)
+            parse(".")
         )
     }
 
     #[test]
     fn should_parse_capture_start_of_string_anchor() {
         use ast::*;
-
-        let pattern = "((?:\\Aa)|(?:b))";
-        let input = pattern.chars().enumerate().collect::<Vec<(usize, char)>>();
 
         assert_eq!(
             Ok(Regex::Unanchored(Expression(vec![SubExpression(vec![
@@ -1017,7 +996,7 @@ mod tests {
                     ])
                 }),
             ])]))),
-            parse(&input)
+            parse("((?:\\Aa)|(?:b))")
         )
     }
 }


### PR DESCRIPTION
# Introduction
This PR updates the updates the `parse` method to accept a more friendly `AsRef<str>` rather than the enumerated `&[(usize, char)]` and instead implements a new method `parse_enumerated_slice` for the latter.

# Linked Issues
resolves #24 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
