### PR TITLE
Reduce explicit chars to single set

### DIFF
--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -204,14 +204,8 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
                     let _ = sets.get(idx).unwrap();
                     Instructions::new(sets, insts).with_fast_forward(FastForward::Set(idx))
                 }
-                (
-                    false,
-                    Some(Opcode::Epsilon(InstEpsilon {
-                        cond: EpsilonCond::WordBoundary,
-                    })),
-                ) => Instructions::new(sets, insts),
                 // catch-all
-                (false, None) | (false, Some(_)) | (true, _) => Instructions::new(sets, insts),
+                _ => Instructions::new(sets, insts),
             }
         })
 }

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -200,7 +200,7 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
                 }
                 (false, Some(Opcode::ConsumeSet(InstConsumeSet { idx }))) => {
                     // panics if the set is undefined.
-                    // This should never happend
+                    // This should never happen.
                     let _ = sets.get(idx).unwrap();
                     Instructions::new(sets, insts).with_fast_forward(FastForward::Set(idx))
                 }

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -204,7 +204,8 @@ pub fn compile(regex_ast: ast::Regex) -> Result<Instructions, String> {
                     let _ = sets.get(idx).unwrap();
                     Instructions::new(sets, insts).with_fast_forward(FastForward::Set(idx))
                 }
-                // catch-all
+                // This disables fast-forward for all other cases whcih
+                // primarily should be either an anchored or empty program.
                 _ => Instructions::new(sets, insts),
             }
         })


### PR DESCRIPTION
# Introduction
This PR folds explicit character alphabets back into a single explicit alphabet and re-enables fast-forward for the Explicit set type as disabled in #35.

# Linked Issues
resolves #34 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
