### PR TITLE
Deprecate join method which panics on unicode

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -656,6 +656,7 @@ pub enum CharacterAlphabet {
 
 impl CharacterAlphabet {
     /// Joins a group of character sets into a single `Ranges` variant character set.
+    #[deprecated = "Removing to eliminate the risk of runtime fallibility from a unicode category."]
     pub fn join(sets: Vec<Self>) -> CharacterAlphabet {
         let ranges = sets
             .into_iter()


### PR DESCRIPTION
# Introduction
This pr deprecates the CharacterAlphabet `join` method which is unused but panics on unicode categories.

Additionally this adds a new error for invalid opcode deserialization rather than panic'ing on a `todo!()`

# Linked Issues
resolves #37 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
