### PR TITLE
All public error types should return str

### DIFF
--- a/compiler/examples/re/main.rs
+++ b/compiler/examples/re/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), String> {
     }?;
 
     let program = parse(pattern)
-        .map_err(|e| format!("{:?}", e))
+        .map_err(|e| e.to_string())
         .and_then(compile)?;
 
     if debug {

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -103,7 +103,7 @@ pub struct GroupNonCapturingModifier;
 // Matchers
 
 /// A consuming match consuming against a few match cases defined from its MatchItem.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Match {
     /// A quantified match, ex: `a*`.
     WithQuantifier {
@@ -118,7 +118,7 @@ impl SubExpressionItemConvertible for Match {}
 
 /// The inner representation of a match.
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum MatchItem {
     /// Represents any unicode character, ex: `.`.
     MatchAnyCharacter,
@@ -158,7 +158,7 @@ impl MatchItemConvertible for MatchAnyCharacter {}
 
 /// Represents a character class match.
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum MatchCharacterClass {
     /// A group, or set, of characters, `[0-9]` or `[abcd]`.
     CharacterGroup(CharacterGroup),
@@ -192,14 +192,14 @@ impl From<CharacterClassFromUnicodeCategory> for MatchCharacterClass {
 }
 
 /// Represents a consuming match against a single unicode character.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MatchCharacter(pub Char);
 impl MatchItemConvertible for MatchCharacter {}
 
 // Character Classes
 
 /// A set of characters or groups to match against.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CharacterGroup {
     /// Represents that the matching set is exclusive of the defined group
     /// items, ex: `[^abcd]`
@@ -216,7 +216,7 @@ pub struct CharacterGroupNegativeModifier;
 
 /// The inner representation of a character group.
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CharacterGroupItem {
     /// A character class, `\d` or `\w`.
     CharacterClass(CharacterClass),
@@ -262,7 +262,7 @@ impl From<Char> for CharacterGroupItem {
 
 /// A Regex character class.
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CharacterClass {
     /// An any word match, `\w`.
     AnyWord,
@@ -321,14 +321,14 @@ pub struct CharacterClassAnyDecimalDigitInverted;
 impl CharacterClassConvertible for CharacterClassAnyDecimalDigitInverted {}
 
 /// Represents a unicode category character class.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CharacterClassFromUnicodeCategory(pub UnicodeCategoryName);
 impl MatchCharacterClassConvertible for CharacterClassFromUnicodeCategory {}
 impl CharacterGroupItemConvertible for CharacterClassFromUnicodeCategory {}
 
 /// An enum representation of possible Unicode General Categories specifiable
 /// in the unicode category character class matchers.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UnicodeCategoryName {
     Letter,
     LowercaseLetter,
@@ -396,7 +396,7 @@ impl CharacterGroupItemConvertible for CharacterRange {}
 /// - {2}
 /// - {2,4}
 /// - {2,}
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Quantifier {
     /// Represents an eager quantifier, ex. `*`.
     Eager(QuantifierType),
@@ -409,7 +409,7 @@ pub enum Quantifier {
 pub trait IsQuantifierType: Into<QuantifierType> {}
 
 /// Represents all variants of quantifier types
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum QuantifierType {
     /// Represents a quantifier matching a specified exact number of elements.
     /// Represented by the `{n}` quantifier where `n` is a positive integer.
@@ -538,7 +538,7 @@ pub struct StartOfStringAnchor;
 pub trait AnchorConvertible: Into<Anchor> {}
 
 /// An Anchor element in the AST containing both anchor and boundary elements.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Anchor {
     /// A word boundary, ex. `\b`.
     WordBoundary,
@@ -631,7 +631,7 @@ impl AnchorConvertible for AnchorEndOfString {}
 // Terminals
 
 /// Representative of a positive integer in ast.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Integer(pub usize);
 
@@ -648,7 +648,7 @@ impl From<Integer> for usize {
 }
 
 /// Represents one or more unicode characters.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Letters(pub Vec<char>);
 
@@ -665,7 +665,7 @@ impl AsRef<[char]> for Letters {
 }
 
 /// Represents a single unicode character.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Char(pub char);
 impl CharacterGroupItemConvertible for Char {}

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -53,4 +53,4 @@ pub mod parser;
 
 pub use bytecode::to_binary;
 pub use compiler::{compile, compile_many};
-pub use parser::{parse, ParseErr};
+pub use parser::{parse, ParseErr, ParseErrKind};

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -27,7 +27,7 @@ use super::ast;
 
 /// Represents an error stemming from parsing of an input string into a regex
 /// AST.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum ParseErr {
     InvalidRegex,
     Undefined(String),

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -27,7 +27,9 @@ use super::ast;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ParseErrKind {
+    /// Represents an invalid expression,
     InvalidRegex,
+    /// Represents all other errors.
     Other,
 }
 
@@ -49,15 +51,21 @@ pub struct ParseErr {
 }
 
 impl ParseErr {
+    /// Instantiates a new error with an error kind
     pub fn new(kind: ParseErrKind) -> Self {
         Self { kind, data: None }
     }
 
-    pub fn with_data(self, data: String) -> Self {
-        Self {
-            kind: self.kind,
-            data: Some(data),
-        }
+    /// Assigns contextual data in `String` format to the error.
+    pub fn with_data_mut(&mut self, data: String) {
+        self.data = Some(data);
+    }
+
+    /// Add additional contextual data in `String` format, consuming the
+    /// original error and returning a new error with the data.
+    pub fn with_data(mut self, data: String) -> Self {
+        self.with_data_mut(data);
+        self
     }
 }
 

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -25,13 +25,13 @@ use parcel::prelude::v1::*;
 
 use super::ast;
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ParseErrKind {
     InvalidRegex,
     Other,
 }
 
-impl std::fmt::Debug for ParseErrKind {
+impl std::fmt::Display for ParseErrKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Other => write!(f, "undefined parse error"),
@@ -42,7 +42,7 @@ impl std::fmt::Debug for ParseErrKind {
 
 /// Represents an error stemming from parsing of an input string into a regex
 /// AST.
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseErr {
     kind: ParseErrKind,
     data: Option<String>,
@@ -61,18 +61,12 @@ impl ParseErr {
     }
 }
 
-impl std::fmt::Debug for ParseErr {
+impl std::fmt::Display for ParseErr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.data {
-            Some(data) => write!(f, "{:?}: {}", &self.kind, data),
-            None => write!(f, "{:?}", &self.kind),
+            Some(data) => write!(f, "{}: {}", &self.kind, data),
+            None => write!(f, "{}", &self.kind),
         }
-    }
-}
-
-impl ToString for ParseErr {
-    fn to_string(&self) -> String {
-        format!("{:?}", self)
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -228,7 +228,7 @@ impl<const SG: usize> Default for Threads<SG> {
 
 /// Representative the first consuming match that the runtime can fast-forward
 /// to in an input.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FastForward {
     /// Represents a single character.
     Char(char),
@@ -247,7 +247,7 @@ impl Default for FastForward {
 /// Represents a runtime program, consisting of all character sets referenced
 /// in an evaluation, all instructions in the program and whether the runtime
 /// can fast-forward through an input.
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Eq)]
 pub struct Instructions {
     pub sets: Vec<CharacterSet>,
     pub program: Vec<Instruction>,
@@ -429,7 +429,7 @@ impl std::ops::Add<Self> for InstIndex {
 pub struct OpcodeBytecodeRepr(pub [u8; 16]);
 
 /// A runtime instruction, containing an offset and a corresponding instruction.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Instruction {
     // A unique identifier for a given instruction
     pub offset: usize,
@@ -485,7 +485,7 @@ impl Display for Instruction {
 }
 
 /// An enum representation of the runtime's operation set.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Opcode {
     /// A consume operation, matching any character.
     Any,
@@ -563,7 +563,7 @@ impl Display for Opcode {
 }
 
 /// A concrete representation of the Any Opcode.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct InstAny;
 
 impl InstAny {
@@ -588,7 +588,7 @@ impl Display for InstAny {
 }
 
 /// A concrete representation of the Consume Opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstConsume {
     /// An expected unicode character required to match.
     pub value: char,
@@ -642,7 +642,7 @@ pub trait CharacterSetRepresentable: Into<CharacterSet> {}
 
 /// Representing a runtime-dispatchable set of characters by associating a sets
 /// membership to a character alphabet.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CharacterSet {
     pub membership: SetMembership,
     pub set: CharacterAlphabet,
@@ -696,7 +696,7 @@ impl CharacterRangeSetVerifiable for CharacterSet {
 }
 
 /// Represents a runtime dispatchable set of characters.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CharacterAlphabet {
     /// Represents a range of values i.e. `0-9`, `a-z`, `A-Z`, etc...
     Range(std::ops::RangeInclusive<char>),
@@ -887,7 +887,7 @@ pub enum SetMembership {
 /// ConsumeSet provides richer matching patterns than the more constrained
 /// Consume or Any instructions allowing for the matching from a set of
 /// characters. This functions as a brevity tool to prevent long alternations.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstConsumeSet {
     /// A offset id to a predefined set in the current program.
     pub idx: usize,
@@ -926,7 +926,7 @@ pub enum EpsilonCond {
 }
 
 /// An internal representation of an `Epsilon` opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstEpsilon {
     pub cond: EpsilonCond,
 }
@@ -957,7 +957,7 @@ impl Display for InstEpsilon {
 }
 
 /// An internal representation of the `Split` opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstSplit {
     pub x_branch: InstIndex,
     pub y_branch: InstIndex,
@@ -989,7 +989,7 @@ impl Display for InstSplit {
 }
 
 /// An internal representation of the `Jmp` opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstJmp {
     pub next: InstIndex,
 }
@@ -1010,7 +1010,7 @@ impl Display for InstJmp {
 }
 
 /// An internal representation of the `StartSave` opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstStartSave {
     pub slot_id: usize,
 }
@@ -1032,7 +1032,7 @@ impl Display for InstStartSave {
 }
 
 /// An internal representation of the `EndSave` opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstEndSave {
     pub slot_id: usize,
 }
@@ -1054,7 +1054,7 @@ impl Display for InstEndSave {
 }
 
 /// An internal representation of the `Match` opcode.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct InstMatch;
 
 impl InstMatch {
@@ -1068,7 +1068,7 @@ impl Display for InstMatch {
 }
 
 /// An internal representation of the `Meta` opcode.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstMeta(pub MetaKind);
 
 impl InstMeta {
@@ -1088,7 +1088,7 @@ impl Display for InstMeta {
 }
 
 /// Represents the kind of Metadata operation to trigger.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MetaKind {
     /// Sets expression id on a thread. This _ONLY_ comes into play in
     /// multi-expression runs.


### PR DESCRIPTION
# Introduction
This PR implements `Display`, and by extension `ToString` on all error kinds to make it easy to format and convert them to string representations.
# Linked Issues
#47 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
