### PR TITLE
Ci/49/switch to dtolnay rust toolchain

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -20,7 +20,7 @@ jobs:
           clean: false
       - uses: dtolnay/rust-toolchain@stable
       - name: measure benchmarks on branch
-      - run: cargo bench 
+        run: cargo bench 
       - name: upload benchmark report
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -15,13 +15,12 @@ jobs:
     name: Bench
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           clean: false
+      - uses: dtolnay/rust-toolchain@stable
       - name: measure benchmarks on branch
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
+      - run: cargo bench 
       - name: upload benchmark report
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,6 @@ jobs:
   unit_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - run: cargo test --all-features


### PR DESCRIPTION
# Introduction
Switch to dtolnay/rust-toolchain where applicable.

# Linked Issues
resolves #49 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
