### PR TITLE
feat: matcher backend

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
 	"name": "Rust",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye"
-
-	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 workspace = ".."
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 
 [[bench]]
 name = "linear_scaling_of_input"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -21,4 +21,3 @@ harness = false
 [dependencies]
 parcel = { git = "https://github.com/ncatelli/parcel", tag = "v2.0.1" }
 regex-runtime = { path = "../runtime/" }
-unicode-categories = { git = "https://github.com/ncatelli/unicode-categories", tag = "v0.2.0" }

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -365,7 +365,7 @@ fn generate_nested_split_expressions(
 
     let mut expr_splits = vec![];
 
-    for offset in (1..split_cnt).into_iter().rev() {
+    for offset in (1..split_cnt).rev() {
         match offset {
             offset if offset == 1 => {
                 // safe to while loop condition asserting 2 elements are present.
@@ -844,7 +844,6 @@ fn character_group(cg: ast::CharacterGroup) -> Result<RelativeOpcodes, String> {
     let sets: Vec<RelativeOpcodes> = explicit_alphabet
         .into_iter()
         .chain(other_alphabets)
-        .into_iter()
         .map(|alphabet| {
             if negated {
                 CharacterSet::exclusive(alphabet)

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -42,10 +42,6 @@
 //! )
 //! ```
 
-#![warn(clippy::cast_lossless)]
-#![warn(clippy::cast_possible_truncation)]
-#![warn(clippy::cast_possible_wrap)]
-
 pub mod ast;
 pub mod bytecode;
 pub mod compiler;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 workspace = ".."
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 
 [[bench]]
 name = "linear_scaling_of_input"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,5 +19,4 @@ path = "benches/deserialization.rs"
 harness = false
 
 [dependencies]
-collections-ext = { git = "https://github.com/ncatelli/collections-ext", branch = "main" }
 unicode-categories = { git = "https://github.com/ncatelli/unicode-categories", tag = "v0.2.0" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -39,6 +39,9 @@ use std::fmt::{Debug, Display};
 pub mod bytecode;
 pub use bytecode::from_binary;
 
+/// Methods for defining and composing matchers.
+pub mod matcher;
+
 mod sparse_set;
 use sparse_set::SparseSet;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -41,9 +41,10 @@ pub mod bytecode;
 pub use bytecode::from_binary;
 
 /// Represents a defined match group for a pattern.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SaveGroupSlot {
     /// No valid match for the slot has been found.
+    #[default]
     None,
     /// A valid match has been found between the exlusive range of `start..end`.
     Complete {
@@ -94,12 +95,6 @@ impl From<SaveGroup> for SaveGroupSlot {
                 ..
             } => SaveGroupSlot::complete(expression_id, start, end),
         }
-    }
-}
-
-impl Default for SaveGroupSlot {
-    fn default() -> Self {
-        SaveGroupSlot::None
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,11 +34,13 @@
 //! }
 //! ```
 
-use collections_ext::set::sparse::SparseSet;
 use std::fmt::{Debug, Display};
 
 pub mod bytecode;
 pub use bytecode::from_binary;
+
+mod sparse_set;
+use sparse_set::SparseSet;
 
 /// Represents a defined match group for a pattern.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -134,6 +134,27 @@ enum EvaluationBranch {
     Pe2,
 }
 
+/// Matches the concatenation of two patterns, similar to a logical and.
+///
+/// # Examples
+///
+/// ```
+/// use regex_runtime::matcher::*;
+///
+///  // ab
+///  let mut concat = Concatenation::new(Literal::new('a'), Literal::new('b'));
+///
+///  // happy path with "ab" input.
+///  concat.initial_state_mut();
+///  assert!(concat.advance_mut(&'a'));
+///  assert!(concat.advance_mut(&'b'));
+///  assert!(concat.is_in_accept_state());
+///
+///  // happy path with "ab" input.
+///  concat.initial_state_mut();
+///  assert!(concat.advance_mut(&'a'));
+///  assert!(!concat.advance_mut(&'c'));
+/// ```
 pub struct Concatenation<T, PE1, PE2> {
     item_ty: std::marker::PhantomData<T>,
     which: EvaluationBranch,
@@ -191,6 +212,28 @@ where
     }
 }
 
+/// Implements regular expression alternation, a logical or.
+///
+/// # Examples
+///
+/// ```
+/// use regex_runtime::matcher::*;
+///
+/// let mut alternation = Alternation::new(Literal::new('a'), Literal::new('b'));
+///
+/// // happy path with either 'a' or 'b' input.
+/// alternation.initial_state_mut();
+/// assert!(alternation.advance_mut(&'a'));
+/// assert!(alternation.is_in_accept_state());
+///
+/// alternation.initial_state_mut();
+/// assert!(alternation.advance_mut(&'b'));
+/// assert!(alternation.is_in_accept_state());
+///
+/// // fails with anything else
+/// alternation.initial_state_mut();
+/// assert!(!alternation.advance_mut(&'c'));
+/// ```
 pub struct Alternation<T, PE1, PE2> {
     item_ty: std::marker::PhantomData<T>,
 
@@ -267,24 +310,5 @@ mod tests {
         concat.initial_state_mut();
         assert!(concat.advance_mut(&'a'));
         assert!(!concat.advance_mut(&'c'));
-    }
-
-    #[test]
-    fn should_alternate_between_two_valid_evaluators() {
-        // a | b
-        let mut alternation = Alternation::new(Literal::new('a'), Literal::new('b'));
-
-        // happy path with either 'a' or 'b' input.
-        alternation.initial_state_mut();
-        assert!(alternation.advance_mut(&'a'));
-        assert!(alternation.is_in_accept_state());
-
-        alternation.initial_state_mut();
-        assert!(alternation.advance_mut(&'b'));
-        assert!(alternation.is_in_accept_state());
-
-        // fails with anything else
-        alternation.initial_state_mut();
-        assert!(!alternation.advance_mut(&'c'));
     }
 }

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -155,5 +155,147 @@ impl<T: Eq> PatternEvaluatorMut for Literal<T> {
     }
 }
 
+/// Concatenates to matchers, matching them sequentially.
+///
+/// # Examples
+///
+/// ```
+/// use regex_runtime::matcher::*;
+///
+/// let literal_a = Literal::new('a').initial_state();
+/// let literal_b = Literal::new('b').initial_state();
+/// let mut concat = Concatenation::new(literal_a, literal_b).initial_state();
+///
+/// // Advances one character that matches the expected literal.
+/// assert!(concat.matches("ab".chars()));
+/// assert!(concat.is_in_accept_state());
+/// ```
+pub struct Concatenation<T, PE1, PE2> {
+    ty: std::marker::PhantomData<T>,
+    pe1: PE1,
+    pe2_started: bool,
+    pe2: PE2,
+}
+
+impl<T, PE1, PE2> Concatenation<T, PE1, PE2>
+where
+    PE1: PatternEvaluatorMut<Item = T>,
+    PE2: PatternEvaluatorMut<Item = T>,
+{
+    #[must_use]
+    pub fn new(pe1: PE1, pe2: PE2) -> Self {
+        Self {
+            ty: std::marker::PhantomData,
+            pe1,
+            pe2_started: false,
+            pe2,
+        }
+    }
+}
+
+impl<T, PE1, PE2> PatternEvaluatorMut for Concatenation<T, PE1, PE2>
+where
+    PE1: PatternEvaluatorMut<Item = T>,
+    PE2: PatternEvaluatorMut<Item = T>,
+{
+    type Item = T;
+
+    fn initial_state_mut(&mut self) {
+        // clear the acceptor state if set and set as in initial state.
+        self.pe1.initial_state_mut();
+
+        let pe1_in_accept_state = self.pe1.is_in_accept_state();
+        self.pe2_started = pe1_in_accept_state;
+
+        if self.pe2_started {
+            self.pe2.initial_state_mut();
+        }
+    }
+
+    fn is_in_accept_state(&self) -> bool {
+        self.pe2.is_in_accept_state()
+    }
+
+    fn advance_mut<'a>(&mut self, next: &'a Self::Item) -> Option<&'a Self::Item> {
+        if self.pe2_started {
+            self.pe2.advance_mut(next)
+        } else {
+            let pe1_advanced = self.pe1.advance_mut(next);
+            self.pe2_started = self.pe1.is_in_accept_state();
+
+            pe1_advanced
+        }
+    }
+}
+
+/// Matches either of two sub-matchers.
+///
+/// # Examples
+///
+/// ```
+/// use regex_runtime::matcher::*;
+///
+/// let literal_a = Literal::new('a').initial_state();
+/// let literal_b = Literal::new('b').initial_state();
+/// let mut alt = Alternation::new(literal_a, literal_b).initial_state();
+///
+/// // matches either a | b.
+/// assert!(alt.matches("a".chars()));
+/// assert!(alt.is_in_accept_state());
+///
+/// alt.initial_state_mut();
+/// assert!(alt.matches("b".chars()));
+/// assert!(alt.is_in_accept_state());
+///
+/// alt.initial_state_mut();
+/// assert!(!alt.matches("c".chars()));
+/// assert!(!alt.is_in_accept_state());
+///
+/// ```
+pub struct Alternation<T, PE1, PE2> {
+    ty: std::marker::PhantomData<T>,
+    pe1: PE1,
+    pe2: PE2,
+}
+
+impl<T, PE1, PE2> Alternation<T, PE1, PE2>
+where
+    PE1: PatternEvaluatorMut<Item = T>,
+    PE2: PatternEvaluatorMut<Item = T>,
+{
+    pub fn new(pe1: PE1, pe2: PE2) -> Self {
+        Self {
+            ty: std::marker::PhantomData,
+            pe1,
+            pe2,
+        }
+    }
+}
+impl<T, PE1, PE2> PatternEvaluatorMut for Alternation<T, PE1, PE2>
+where
+    PE1: PatternEvaluatorMut<Item = T>,
+    PE2: PatternEvaluatorMut<Item = T>,
+{
+    type Item = T;
+
+    fn initial_state_mut(&mut self) {
+        self.pe1.initial_state_mut();
+        self.pe2.initial_state_mut();
+    }
+
+    fn is_in_accept_state(&self) -> bool {
+        self.pe1.is_in_accept_state() || self.pe2.is_in_accept_state()
+    }
+
+    fn advance_mut<'a>(&mut self, next: &'a Self::Item) -> Option<&'a Self::Item> {
+        let pe1_advanced = self.pe1.advance_mut(next);
+        if pe1_advanced.is_some() {
+            pe1_advanced
+        } else {
+            self.pe2.advance_mut(next)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {}

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -293,22 +293,4 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn should_join_two_valid_evaluators() {
-        // ab
-        let mut concat = Concatenation::new(Literal::new('a'), Literal::new('b'));
-
-        // happy path with "ab" input.
-        concat.initial_state_mut();
-        assert!(concat.advance_mut(&'a'));
-        assert!(concat.advance_mut(&'b'));
-
-        // happy path with "ab" input.
-        concat.initial_state_mut();
-        assert!(concat.advance_mut(&'a'));
-        assert!(!concat.advance_mut(&'c'));
-    }
-}
+mod tests {}

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -1,10 +1,11 @@
-pub trait PatternEvaluatorMut {
+pub trait PatternEvaluatorMut: Sized {
     /// The input interable type to be compared.
     type Item;
 
-    /// Resets the evaluator to it's initial state and clears any contextual
-    /// state.
-    fn reset_mut(&mut self);
+    fn initial_state(mut self) -> Self {
+        self.initial_state_mut();
+        self
+    }
 
     /// Defines the evaluator as being in the initial state. Without resetting
     /// contextual state.
@@ -13,12 +14,20 @@ pub trait PatternEvaluatorMut {
     /// Returns a boolean signifying if the match is in a final state.
     fn is_in_accept_state(&self) -> bool;
 
-    // signifies there are no additional transitions
-    fn is_completed(&self) -> bool;
-
-    /// Attempts to advance to the next state, returning a boolean signifying
+    /// Attempts to advance to the next state, returning an [Option] signifying
     /// the success of that advance.
-    fn advance_mut(&mut self, next: &Self::Item) -> bool;
+    fn advance_mut<'a>(&mut self, next: &'a Self::Item) -> Option<&'a Self::Item>;
+
+    fn matches<I>(&mut self, iter: I) -> bool
+    where
+        I: Iterator<Item = Self::Item>,
+    {
+        iter.fold(self.is_in_accept_state(), |_, item| {
+            self.advance_mut(&item);
+
+            self.is_in_accept_state()
+        })
+    }
 }
 
 /// Matches a given value.
@@ -28,22 +37,27 @@ pub trait PatternEvaluatorMut {
 /// ```
 /// use regex_runtime::matcher::*;
 ///
-/// let mut literal_char = Literal::new('a');
-/// literal_char.initial_state_mut();
-/// assert!(literal_char.advance_mut(&'a'));
+/// let mut literal_char = Literal::new('a').initial_state();
+///
+/// // Advances one character that matches the expected literal.
+/// assert_eq!(Some(&'a'), literal_char.advance_mut(&'a'));
 /// assert!(literal_char.is_in_accept_state());
-/// assert!(literal_char.is_completed());
+///
+/// // Fails to match 'b'.
+/// literal_char.initial_state_mut();
+/// assert!(literal_char.advance_mut(&'b').is_none());
+/// assert!(!literal_char.is_in_accept_state());
 ///
 /// literal_char.initial_state_mut();
-/// assert!(!literal_char.advance_mut(&'b'));
-/// assert!(!literal_char.is_in_accept_state());
-/// assert!(literal_char.is_completed());
+/// assert!(literal_char.matches("a".chars()));
+///
+/// literal_char.initial_state_mut();
+/// assert!(!literal_char.matches("ab".chars()));
 /// ```
 pub struct Literal<T> {
     literal: T,
     in_initial_state: bool,
-    in_acceptor_state: bool,
-    completed: bool,
+    is_in_final_state: bool,
 }
 
 impl<T> Literal<T> {
@@ -51,9 +65,8 @@ impl<T> Literal<T> {
     pub fn new(literal: T) -> Self {
         Self {
             literal,
-            in_initial_state: false,
-            in_acceptor_state: false,
-            completed: false,
+            in_initial_state: true,
+            is_in_final_state: false,
         }
     }
 }
@@ -61,603 +74,22 @@ impl<T> Literal<T> {
 impl<T: Eq> PatternEvaluatorMut for Literal<T> {
     type Item = T;
 
-    fn reset_mut(&mut self) {
-        self.initial_state_mut()
-    }
-
     fn initial_state_mut(&mut self) {
         // clear the acceptor state if set and set as in initial state.
         self.in_initial_state = true;
-        self.completed = !self.in_initial_state;
-        self.in_acceptor_state = false;
     }
 
     fn is_in_accept_state(&self) -> bool {
-        self.in_acceptor_state
+        self.is_in_final_state
     }
 
-    fn is_completed(&self) -> bool {
-        self.completed
-    }
-
-    fn advance_mut(&mut self, next: &Self::Item) -> bool {
-        if self.is_completed() {
-            return false;
-        }
-
-        // transition out of initial state.
-        self.in_initial_state = false;
-        self.completed = true;
-        self.in_acceptor_state = &self.literal == next;
-        self.in_acceptor_state
-    }
-}
-
-/// Matches any single value.
-///
-/// # Examples
-///
-/// ```
-/// use regex_runtime::matcher::*;
-///
-/// let mut any_char = Any::new();
-/// any_char.initial_state_mut();
-/// assert!(any_char.advance_mut(&'a'));
-/// assert!(any_char.is_in_accept_state());
-/// assert!(any_char.is_completed());
-/// ```
-pub struct Any<T> {
-    item_ty: std::marker::PhantomData<T>,
-    in_initial_state: bool,
-    in_acceptor_state: bool,
-    completed: bool,
-}
-
-impl<T> Any<T> {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            item_ty: std::marker::PhantomData,
-            in_initial_state: true,
-            completed: false,
-            in_acceptor_state: false,
-        }
-    }
-}
-
-impl<T> PatternEvaluatorMut for Any<T> {
-    type Item = T;
-
-    fn reset_mut(&mut self) {
-        self.initial_state_mut()
-    }
-
-    fn initial_state_mut(&mut self) {
-        // clear the acceptor state if set and set as in initial state.
-        self.in_initial_state = true;
-        self.completed = !self.in_initial_state;
-        self.in_acceptor_state = false;
-    }
-
-    fn is_in_accept_state(&self) -> bool {
-        self.in_acceptor_state
-    }
-
-    fn is_completed(&self) -> bool {
-        self.completed
-    }
-
-    fn advance_mut(&mut self, _: &Self::Item) -> bool {
-        if self.is_completed() {
-            return false;
-        }
-
-        // transition out of initial state.
-        self.in_initial_state = false;
-        self.completed = true;
-        self.in_acceptor_state = true;
-        self.in_acceptor_state
-    }
-}
-
-impl<T> Default for Any<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Matches the concatenation of two patterns, similar to a logical and.
-///
-/// # Examples
-///
-/// ```
-/// use regex_runtime::matcher::*;
-///
-///  // ab
-///  let mut concat = Concatenation::new(Literal::new('a'), Literal::new('b'));
-///
-///  // happy path with "ab" input.
-///  concat.initial_state_mut();
-///  assert!(concat.advance_mut(&'a'));
-///  assert!(concat.advance_mut(&'b'));
-///  assert!(concat.is_in_accept_state());
-///
-///  // happy path with "ab" input.
-///  concat.initial_state_mut();
-///  assert!(concat.advance_mut(&'a'));
-///  assert!(!concat.advance_mut(&'c'));
-/// ```
-pub struct Concatenation<T, PE1, PE2> {
-    item_ty: std::marker::PhantomData<T>,
-    pe1: PE1,
-    pe1_was_accepted: bool,
-    pe1_was_completed: bool,
-    pe2: PE2,
-}
-
-impl<T, PE1, PE2> Concatenation<T, PE1, PE2> {
-    pub fn new(pe1: PE1, pe2: PE2) -> Self {
-        Self {
-            item_ty: std::marker::PhantomData,
-            pe1,
-            pe1_was_accepted: false,
-            pe1_was_completed: false,
-            pe2,
-        }
-    }
-}
-
-impl<T, PE1, PE2> PatternEvaluatorMut for Concatenation<T, PE1, PE2>
-where
-    PE1: PatternEvaluatorMut<Item = T>,
-    PE2: PatternEvaluatorMut<Item = T>,
-{
-    type Item = T;
-
-    fn reset_mut(&mut self) {
-        self.pe1.reset_mut();
-        self.pe1_was_accepted = false;
-        self.pe1_was_completed = false;
-        self.pe2.reset_mut();
-    }
-
-    fn initial_state_mut(&mut self) {
-        self.pe1.initial_state_mut();
-        self.pe1_was_accepted = false;
-        self.pe1_was_completed = false;
-        self.pe2.initial_state_mut();
-    }
-
-    fn is_in_accept_state(&self) -> bool {
-        self.pe1_was_accepted && self.pe2.is_in_accept_state()
-    }
-
-    fn is_completed(&self) -> bool {
-        self.pe1.is_completed() && self.pe2.is_completed()
-    }
-
-    fn advance_mut(&mut self, next: &Self::Item) -> bool {
-        if self.is_completed() {
-            return false;
-        }
-
-        let pe1_was_accepted = self.pe1.is_in_accept_state();
-
-        let pe1_advanced = if !self.pe1_was_completed {
-            self.pe1.advance_mut(next)
-        } else {
-            false
-        };
-
-        if !pe1_advanced && pe1_was_accepted {
-            self.pe1_was_accepted = true;
-            self.pe1_was_completed = true;
-        } else if !pe1_advanced {
-            self.pe1_was_completed = true;
-        }
-
-        let pe1_was_completed_and_accepted = self.pe1_was_accepted && self.pe1_was_completed;
-
-        let pe2_advanced = self.pe2.advance_mut(next);
-        if (pe1_was_completed_and_accepted) && pe2_advanced {
-            pe2_advanced
-        } else if pe1_advanced && !pe2_advanced {
-            self.pe2.reset_mut();
-            true
-        } else {
-            false
-        }
-    }
-}
-
-/// Implements regular expression alternation, a logical or.
-///
-/// # Examples
-///
-/// ```
-/// use regex_runtime::matcher::*;
-///
-/// let mut alternation = Alternation::new(Literal::new('a'), Literal::new('b'));
-///
-/// // happy path with either 'a' or 'b' input.
-/// alternation.initial_state_mut();
-/// assert!(alternation.advance_mut(&'a'));
-/// assert!(alternation.is_in_accept_state());
-///
-/// alternation.initial_state_mut();
-/// assert!(alternation.advance_mut(&'b'));
-/// assert!(alternation.is_in_accept_state());
-///
-/// // fails with anything else
-/// alternation.initial_state_mut();
-/// assert!(!alternation.advance_mut(&'c'));
-/// ```
-pub struct Alternation<T, PE1, PE2> {
-    item_ty: std::marker::PhantomData<T>,
-
-    pe1: PE1,
-    pe2: PE2,
-}
-
-impl<T, PE1, PE2> Alternation<T, PE1, PE2> {
-    pub fn new(pe1: PE1, pe2: PE2) -> Self {
-        Self {
-            item_ty: std::marker::PhantomData,
-            pe1,
-            pe2,
-        }
-    }
-}
-
-impl<T, PE1, PE2> PatternEvaluatorMut for Alternation<T, PE1, PE2>
-where
-    PE1: PatternEvaluatorMut<Item = T>,
-    PE2: PatternEvaluatorMut<Item = T>,
-{
-    type Item = T;
-
-    fn reset_mut(&mut self) {
-        self.pe1.reset_mut();
-        self.pe2.reset_mut();
-    }
-
-    fn initial_state_mut(&mut self) {
-        self.pe1.initial_state_mut();
-        self.pe2.initial_state_mut();
-    }
-
-    fn is_in_accept_state(&self) -> bool {
-        self.pe1.is_in_accept_state() || self.pe2.is_in_accept_state()
-    }
-
-    fn is_completed(&self) -> bool {
-        self.pe1.is_completed() && self.pe2.is_completed()
-    }
-
-    fn advance_mut(&mut self, next: &Self::Item) -> bool {
-        if self.is_completed() {
-            return false;
-        };
-
-        let mut either_advanced = false;
-
-        if !self.pe1.is_completed() && self.pe1.advance_mut(next) {
-            either_advanced = true;
-        }
-
-        if !self.pe2.is_completed() && self.pe2.advance_mut(next) {
-            either_advanced = true;
-        }
-
-        either_advanced
-    }
-}
-
-/// Matches either zero or one sub-expressions.
-///
-/// # Examples
-///
-/// ```
-/// use regex_runtime::matcher::*;
-///
-/// let mut zero_or_one = ZeroOrOne::new(Literal::new('a'));
-///
-/// // matches one
-///
-/// zero_or_one.initial_state_mut();
-/// assert!(zero_or_one.advance_mut(&'a'));
-/// assert!(zero_or_one.is_in_accept_state());
-///
-/// // matches zero
-///
-/// zero_or_one.initial_state_mut();
-/// // should not advance but should still be acceptable
-/// assert!(!zero_or_one.advance_mut(&'b'));
-/// assert!(zero_or_one.is_in_accept_state());
-/// ```
-pub struct ZeroOrOne<T, PE> {
-    item_ty: std::marker::PhantomData<T>,
-
-    pe: PE,
-    completed: bool,
-}
-
-impl<T, PE> ZeroOrOne<T, PE> {
-    pub fn new(pe: PE) -> Self {
-        Self {
-            item_ty: std::marker::PhantomData,
-            pe,
-            completed: false,
-        }
-    }
-}
-
-impl<T, PE> PatternEvaluatorMut for ZeroOrOne<T, PE>
-where
-    PE: PatternEvaluatorMut<Item = T>,
-{
-    type Item = T;
-
-    fn reset_mut(&mut self) {
-        self.pe.reset_mut();
-        self.completed = false;
-    }
-
-    fn initial_state_mut(&mut self) {
-        self.pe.initial_state_mut();
-        self.completed = false;
-    }
-
-    fn is_in_accept_state(&self) -> bool {
-        let pe_in_accept_state = self.pe.is_in_accept_state();
-        let pe_evaluated = self.pe.is_completed();
-
-        // either the pe is in an acceptible state or it has been evaluated and ignored.
-        pe_in_accept_state || pe_evaluated
-    }
-
-    fn is_completed(&self) -> bool {
-        self.pe.is_completed()
-    }
-
-    fn advance_mut(&mut self, next: &Self::Item) -> bool {
-        if self.pe.is_completed() {
-            return false;
-        };
-
-        self.pe.advance_mut(next)
-    }
-}
-
-/// Matches either zero or more sub-expressions.
-///
-/// # Examples
-///
-/// ```
-/// use regex_runtime::matcher::*;
-///
-///
-/// // matches one
-///
-/// let mut zero_or_more = ZeroOrMore::new(Literal::new('a'));
-/// zero_or_more.initial_state_mut();
-/// // take more than one
-/// assert!(zero_or_more.advance_mut(&'a'));
-/// assert!(zero_or_more.advance_mut(&'a'));
-/// assert!(zero_or_more.advance_mut(&'a'));
-/// assert!(zero_or_more.is_in_accept_state());
-///
-/// // matches zero
-///
-/// zero_or_more.reset_mut();
-/// zero_or_more.initial_state_mut();
-/// // should not advance but should still be acceptable
-/// assert!(!zero_or_more.advance_mut(&'b'));
-/// assert!(zero_or_more.is_in_accept_state());
-/// ```
-pub struct ZeroOrMore<T, PE> {
-    item_ty: std::marker::PhantomData<T>,
-
-    pe: PE,
-    completed: bool,
-    match_count: usize,
-}
-
-impl<T, PE> ZeroOrMore<T, PE> {
-    pub fn new(pe: PE) -> Self {
-        Self {
-            item_ty: std::marker::PhantomData,
-            pe,
-            completed: false,
-            match_count: 0,
-        }
-    }
-}
-
-impl<T, PE> PatternEvaluatorMut for ZeroOrMore<T, PE>
-where
-    PE: PatternEvaluatorMut<Item = T>,
-{
-    type Item = T;
-
-    fn reset_mut(&mut self) {
-        self.pe.reset_mut();
-        self.completed = false;
-        self.match_count = 0;
-    }
-
-    fn initial_state_mut(&mut self) {
-        self.pe.initial_state_mut();
-        self.completed = false;
-    }
-
-    fn is_in_accept_state(&self) -> bool {
-        let pe_in_accept_state = self.pe.is_in_accept_state();
-        let pe_evaluated = self.pe.is_completed();
-
-        // either the pe is in an acceptible state or it has been evaluated and ignored.
-        pe_in_accept_state || pe_evaluated
-    }
-
-    fn is_completed(&self) -> bool {
-        self.completed
-    }
-
-    fn advance_mut(&mut self, next: &Self::Item) -> bool {
-        if self.pe.is_in_accept_state() && self.pe.is_completed() {
-            self.match_count += 1;
-
-            // reset the sub-expression
-            self.pe.initial_state_mut();
-        };
-
-        // advance until completed
-        if self.pe.advance_mut(next) {
-            true
-        } else {
-            self.completed = true;
-            false
-        }
-    }
-}
-
-/// Matches either one or more sub-expressions.
-///
-/// # Examples
-///
-/// ```
-/// use regex_runtime::matcher::*;
-///
-///
-/// // matches one
-///
-/// let mut one_or_more = OneOrMore::new(Literal::new('a'));
-/// one_or_more.initial_state_mut();
-/// // take more than one
-/// assert!(one_or_more.advance_mut(&'a'));
-/// assert!(one_or_more.advance_mut(&'a'));
-/// assert!(one_or_more.advance_mut(&'a'));
-/// assert!(one_or_more.is_in_accept_state());
-///
-/// // matches one
-///
-/// one_or_more.reset_mut();
-/// one_or_more.initial_state_mut();
-/// // should not advance after the `b` but should still be acceptable
-/// assert!(one_or_more.advance_mut(&'a'));
-/// assert!(!one_or_more.advance_mut(&'b'));
-/// assert!(one_or_more.is_in_accept_state());
-///
-/// // fails to match one
-///
-/// one_or_more.reset_mut();
-/// one_or_more.initial_state_mut();
-/// // should not advance and shouldn't be accepted
-/// assert!(!one_or_more.advance_mut(&'b'));
-/// assert!(!one_or_more.is_in_accept_state());
-/// ```
-pub struct OneOrMore<T, PE> {
-    item_ty: std::marker::PhantomData<T>,
-
-    pe: PE,
-    completed: bool,
-    match_count: usize,
-}
-
-impl<T, PE> OneOrMore<T, PE> {
-    pub fn new(pe: PE) -> Self {
-        Self {
-            item_ty: std::marker::PhantomData,
-            pe,
-            completed: false,
-            match_count: 0,
-        }
-    }
-}
-
-impl<T, PE> PatternEvaluatorMut for OneOrMore<T, PE>
-where
-    PE: PatternEvaluatorMut<Item = T>,
-{
-    type Item = T;
-
-    fn reset_mut(&mut self) {
-        self.pe.reset_mut();
-        self.completed = false;
-        self.match_count = 0;
-    }
-
-    fn initial_state_mut(&mut self) {
-        self.pe.initial_state_mut();
-        self.completed = false;
-    }
-
-    fn is_in_accept_state(&self) -> bool {
-        let pe_in_accept_state = self.pe.is_in_accept_state();
-        let has_atleast_one_match = self.match_count > 0;
-
-        // it's acceptable if it has atleast one match
-        pe_in_accept_state || has_atleast_one_match
-    }
-
-    fn is_completed(&self) -> bool {
-        self.completed
-    }
-
-    fn advance_mut(&mut self, next: &Self::Item) -> bool {
-        if self.pe.is_in_accept_state() && self.pe.is_completed() {
-            self.match_count += 1;
-
-            // reset the sub-expression
-            self.pe.initial_state_mut();
-        };
-
-        // advance until completed
-        if self.pe.advance_mut(next) {
-            true
-        } else {
-            self.completed = true;
-            false
-        }
+    fn advance_mut<'a>(&mut self, next: &'a Self::Item) -> Option<&'a Self::Item> {
+        let next_matches_literal = next == &self.literal;
+
+        self.is_in_final_state = self.in_initial_state && next_matches_literal;
+        self.is_in_final_state.then_some(next)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn should_accepted_unanchored_match_expression() {
-        let input = "aaaab";
-
-        let literal = Literal::new('a');
-        let unanchored_prefix = ZeroOrMore::new(Any::new());
-        let mut expression = Alternation::new(unanchored_prefix, literal);
-
-        expression.initial_state_mut();
-
-        for char in input.chars() {
-            assert!(expression.advance_mut(&char));
-        }
-
-        assert!(expression.is_in_accept_state());
-    }
-
-    #[test]
-    #[ignore = "fixing concat"]
-    fn should_accepted_unanchored_concat_match_expression() {
-        let input = "aaaab";
-
-        let literal = Literal::new('a');
-        let unanchored_prefix = ZeroOrMore::new(Any::new());
-        let mut expression = Concatenation::new(unanchored_prefix, literal);
-
-        expression.initial_state_mut();
-
-        for char in input.chars() {
-            assert!(expression.advance_mut(&char));
-        }
-
-        assert!(expression.is_in_accept_state());
-    }
-}
+mod tests {}

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -1,5 +1,5 @@
 pub trait PatternEvaluatorMut: Sized {
-    /// The input interable type to be compared.
+    /// The input iterable type to be compared.
     type Item;
 
     fn initial_state(mut self) -> Self {
@@ -17,13 +17,30 @@ pub trait PatternEvaluatorMut: Sized {
     /// Attempts to advance to the next state, returning an [Option] signifying
     /// the success of that advance.
     fn advance_mut<'a>(&mut self, next: &'a Self::Item) -> Option<&'a Self::Item>;
+}
+
+pub trait PatternEvaluatorMutExt: Sized {
+    /// The input type to be compared.
+    type Item;
 
     fn matches<I>(&mut self, iter: I) -> bool
     where
-        I: Iterator<Item = Self::Item>,
+        I: IntoIterator<Item = Self::Item>;
+}
+
+impl<T> PatternEvaluatorMutExt for T
+where
+    T: PatternEvaluatorMut,
+{
+    type Item = <T as PatternEvaluatorMut>::Item;
+
+    fn matches<I>(&mut self, iter: I) -> bool
+    where
+        I: IntoIterator<Item = Self::Item>,
     {
         let mut accepted = self.is_in_accept_state();
-        for item in iter {
+
+        for item in iter.into_iter() {
             let advanced = self.advance_mut(&item);
             accepted = self.is_in_accept_state();
             if advanced.is_none() {

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -553,32 +553,4 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-
-    #[test]
-    fn should_match_one_or_more() {
-        use super::*;
-
-        let literal_a = Literal::new('a');
-        let mut one_or_more = OneOrMore::new(literal_a).initial_state();
-
-        // matches one
-        assert!(one_or_more.matches("a".chars()));
-        assert!(one_or_more.is_in_accept_state());
-
-        // matches many
-        one_or_more.initial_state_mut();
-        assert!(one_or_more.matches("aaa".chars()));
-        assert!(one_or_more.is_in_accept_state());
-
-        // will fail if first doesn't match
-        one_or_more.initial_state_mut();
-        assert!(!one_or_more.matches("baa".chars()));
-        assert!(!one_or_more.is_in_accept_state());
-
-        // will not match zero
-        one_or_more.initial_state_mut();
-        assert!(!one_or_more.matches("".chars()));
-        assert!(!one_or_more.is_in_accept_state());
-    }
-}
+mod tests {}

--- a/runtime/src/matcher/mod.rs
+++ b/runtime/src/matcher/mod.rs
@@ -1,0 +1,202 @@
+pub trait PatternEvaluatorMut {
+    /// The input interable type to be compared.
+    type Item;
+
+    // Defines the evaluator as being in the initial state.
+    fn initial_state_mut(&mut self);
+
+    /// Returns a boolean signifying if the match is in a final state.
+    fn is_acceptable(&self) -> bool;
+
+    /// Attempts to advance to the next state, returning a boolean signifying
+    /// the success of that advance.
+    fn advance_mut(&mut self, next: Self::Item) -> bool;
+}
+
+/// Matches a given value.
+///
+/// # Examples
+///
+/// ```
+/// use regex_runtime::matcher::*;
+///
+/// let mut literal_char = Literal::new('a');
+/// literal_char.initial_state_mut();
+/// assert!(literal_char.advance_mut('a'));
+///
+/// literal_char.initial_state_mut();
+/// assert!(!literal_char.advance_mut('b'));
+/// ```
+pub struct Literal<T> {
+    literal: T,
+    in_initial_state: bool,
+    in_acceptor_state: bool,
+}
+
+impl<T> Literal<T> {
+    #[must_use]
+    pub fn new(literal: T) -> Self {
+        Self {
+            literal,
+            in_initial_state: false,
+            in_acceptor_state: false,
+        }
+    }
+}
+
+impl<T: Eq> PatternEvaluatorMut for Literal<T> {
+    type Item = T;
+
+    fn initial_state_mut(&mut self) {
+        // clear the acceptor state if set and set as in initial state.
+        self.in_initial_state = true;
+        self.in_acceptor_state = false;
+    }
+
+    fn is_acceptable(&self) -> bool {
+        self.in_acceptor_state
+    }
+
+    fn advance_mut(&mut self, next: Self::Item) -> bool {
+        if !self.in_initial_state {
+            return false;
+        }
+
+        // transition out of initial state.
+        self.in_initial_state = false;
+        self.in_acceptor_state = self.literal == next;
+        self.in_acceptor_state
+    }
+}
+
+/// Matches any single value.
+///
+/// # Examples
+///
+/// ```
+/// use regex_runtime::matcher::*;
+///
+/// let mut any_char = Any::new();
+/// any_char.initial_state_mut();
+/// assert!(any_char.advance_mut('a'));
+/// ```
+pub struct Any<T> {
+    item_ty: std::marker::PhantomData<T>,
+    in_initial_state: bool,
+    in_acceptor_state: bool,
+}
+
+impl<T> Any<T> {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            item_ty: std::marker::PhantomData,
+            in_initial_state: false,
+            in_acceptor_state: false,
+        }
+    }
+}
+
+impl<T> PatternEvaluatorMut for Any<T> {
+    type Item = T;
+
+    fn initial_state_mut(&mut self) {
+        // clear the acceptor state if set and set as in initial state.
+        self.in_initial_state = true;
+        self.in_acceptor_state = false;
+    }
+
+    fn is_acceptable(&self) -> bool {
+        self.in_acceptor_state
+    }
+
+    fn advance_mut(&mut self, _: Self::Item) -> bool {
+        if !self.in_initial_state {
+            return false;
+        }
+
+        // transition out of initial state.
+        self.in_initial_state = false;
+        self.in_acceptor_state = true;
+        self.in_acceptor_state
+    }
+}
+
+impl<T> Default for Any<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct Concatenation<T, PE1, PE2> {
+    item_ty: std::marker::PhantomData<T>,
+    pe1_accepted: bool,
+    pe1: PE1,
+    pe2: PE2,
+}
+
+impl<T, PE1, PE2> Concatenation<T, PE1, PE2> {
+    pub fn new(pe1: PE1, pe2: PE2) -> Self {
+        Self {
+            item_ty: std::marker::PhantomData,
+            pe1_accepted: false,
+            pe1,
+            pe2,
+        }
+    }
+}
+
+impl<T, PE1, PE2> PatternEvaluatorMut for Concatenation<T, PE1, PE2>
+where
+    PE1: PatternEvaluatorMut<Item = T>,
+    PE2: PatternEvaluatorMut<Item = T>,
+{
+    type Item = T;
+
+    fn initial_state_mut(&mut self) {
+        self.pe1.initial_state_mut();
+        self.pe1_accepted = false;
+    }
+
+    fn is_acceptable(&self) -> bool {
+        self.pe1_accepted && self.pe2.is_acceptable()
+    }
+
+    fn advance_mut(&mut self, next: Self::Item) -> bool {
+        if !self.pe1_accepted {
+            let advanced = self.pe1.advance_mut(next);
+            // check if pe1 has advanced into an accept state.
+            let pe1_accepted = self.pe1.is_acceptable();
+            // if pe1 transitions into an accept state, initialize p2.
+            if pe1_accepted {
+                self.pe1_accepted = pe1_accepted;
+                self.pe2.initial_state_mut();
+            }
+
+            advanced
+        } else {
+            self.pe2.advance_mut(next)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_join_two_valid_evaluators() {
+        // ab
+        let mut concat = Concatenation::new(Literal::new('a'), Literal::new('b'));
+
+        // happy path with "ab" input.
+        concat.initial_state_mut();
+        assert!(concat.advance_mut('a'));
+        assert!(concat.advance_mut('b'));
+
+        // happy path with "ab" input.
+        concat.initial_state_mut();
+        assert!(concat.advance_mut('a'));
+        assert!(!concat.advance_mut('c'));
+    }
+}

--- a/runtime/src/sparse_set.rs
+++ b/runtime/src/sparse_set.rs
@@ -23,17 +23,14 @@ impl SparseSet {
         }
     }
 
-    /// Returns `true` if the set contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.elems == 0
-    }
-
     /// Returns the number of elements that the set can hold without reallocating.
+    #[allow(unused)]
     pub fn capacity(&self) -> usize {
         self.sparse.capacity()
     }
 
     /// Returns the number of elements in the set.
+    #[allow(unused)]
     pub fn len(&self) -> usize {
         self.elems
     }
@@ -49,16 +46,8 @@ impl SparseSet {
             self.resize(val * 2)
         }
 
-        let dense_len = self.dense.len();
-        let sparse_idx = self.sparse[val];
-        if dense_len > sparse_idx && self.dense[sparse_idx].is_none() {
-            self.dense[sparse_idx] = Some(val)
-        } else {
-            self.dense.push(Some(val));
-            self.sparse[val] = dense_len;
-        }
-
-        self.elems += 1;
+        // above capacity check guarantees this call should not panic.
+        unsafe { self.insert_unchecked(val) };
     }
 
     /// Inserts a value into the set.
@@ -96,6 +85,7 @@ impl SparseSet {
             .unwrap_or(false)
     }
 
+    #[allow(unused)]
     pub fn remove(&mut self, val: &usize) -> bool {
         if self.contains(val) {
             // safety guaranteed by above contains check

--- a/runtime/src/sparse_set.rs
+++ b/runtime/src/sparse_set.rs
@@ -1,0 +1,193 @@
+//! Provides an implementation of a SparseSet as an alternative to HashSets.
+
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+
+pub struct SparseSet {
+    elems: usize,
+    dense: Vec<Option<usize>>,
+    sparse: Vec<usize>,
+}
+
+impl SparseSet {
+    /// Initializes a new set of taking a value representing the maximum size
+    /// of the set.
+    #[must_use]
+    pub fn new(max_len: usize) -> Self {
+        Self {
+            elems: 0,
+            // initialize 0th index to non-zero so it doesn't match as a set
+            // member by default.
+            dense: vec![],
+            sparse: vec![0; max_len],
+        }
+    }
+
+    /// Returns `true` if the set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.elems == 0
+    }
+
+    /// Returns the number of elements that the set can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.sparse.capacity()
+    }
+
+    /// Returns the number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.elems
+    }
+
+    /// Inserts a value into the set.
+    pub fn insert(&mut self, val: usize) {
+        if self.contains(&val) {
+            return;
+        }
+
+        if self.sparse.capacity() <= val {
+            // double the size.
+            self.resize(val * 2)
+        }
+
+        let dense_len = self.dense.len();
+        let sparse_idx = self.sparse[val];
+        if dense_len > sparse_idx && self.dense[sparse_idx].is_none() {
+            self.dense[sparse_idx] = Some(val)
+        } else {
+            self.dense.push(Some(val));
+            self.sparse[val] = dense_len;
+        }
+
+        self.elems += 1;
+    }
+
+    /// Inserts a value into the set.
+    ///
+    /// This is the unchecked alternative to `insert`.
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function are responsible that these preconditions are
+    /// satisfied:
+    ///
+    /// * The value must not exceed the max length of the set;
+    ///
+    /// Failing that will cause a panic.
+    pub unsafe fn insert_unchecked(&mut self, val: usize) {
+        let dense_len = self.dense.len();
+        let sparse_idx = self.sparse[val];
+        if dense_len > sparse_idx && self.dense[sparse_idx].is_none() {
+            self.dense[sparse_idx] = Some(val)
+        } else {
+            self.dense.push(Some(val));
+            self.sparse[val] = dense_len;
+        }
+
+        self.elems += 1
+    }
+
+    /// Returns `true` if the set contains a value.
+    pub fn contains(&self, val: &usize) -> bool {
+        self.sparse
+            .get(*val)
+            .map(|&dense_idx| self.dense.get(dense_idx) == Some(&Some(*val)))
+            // if none, the bounds of the set are exceeded and thus doesn't
+            // contain the value.
+            .unwrap_or(false)
+    }
+
+    pub fn remove(&mut self, val: &usize) -> bool {
+        if self.contains(val) {
+            // safety guaranteed by above contains check
+            unsafe { self.remove_unchecked(val) };
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes a value into the set.
+    ///
+    /// This is the unchecked alternative to `remove`.
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function are responsible that these preconditions are
+    /// satisfied:
+    ///
+    /// * The value must not exceed the max length of the set;
+    /// * The value must be defined in the set.
+    ///
+    /// Failing that will cause a panic.
+    unsafe fn remove_unchecked(&mut self, val: &usize) {
+        let dense_idx = self.sparse[*val];
+        self.dense[dense_idx] = None;
+        self.elems -= 1;
+    }
+
+    /// Clears the set, removing all values.
+    pub fn clear(&mut self) {
+        self.elems = 0;
+        self.dense.clear();
+    }
+
+    fn resize(&mut self, new_len: usize) {
+        self.sparse.resize_with(new_len, || 0)
+    }
+}
+
+impl core::fmt::Debug for SparseSet {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SparseSet({:?}", &self.dense)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_cause_resize_on_insert_with_bound_exceed() {
+        let mut set = SparseSet::new(0);
+
+        // set capacity is equivalent to provided max_len.
+        assert!(set.capacity() == 0);
+
+        set.insert(10);
+
+        // after insert capacity is 2x largest insert value.
+        assert!(set.capacity() == 20);
+    }
+
+    #[test]
+    fn should_clear_value_on_delete() {
+        let mut set = SparseSet::new(0);
+
+        set.insert(1);
+        assert!(set.contains(&1));
+        assert_eq!(1, set.len());
+
+        set.remove(&1);
+        assert!(!set.contains(&1));
+        assert_eq!(0, set.len());
+    }
+
+    #[test]
+    fn should_reuse_slots_on_delete() {
+        let mut set = SparseSet::new(0);
+
+        set.insert(1);
+        assert!(set.contains(&1));
+        assert_eq!(1, set.len());
+
+        // assert value was cleared from set
+        set.remove(&1);
+        assert!(!set.contains(&1));
+        assert!(set.dense.len() == 1 && set.dense[0].is_none());
+
+        // Re-add the previous value and assert slot is reused.
+        set.insert(1);
+        assert!(set.contains(&1));
+        assert!(set.dense.len() == 1 && set.dense[0] == Some(1));
+    }
+}


### PR DESCRIPTION
# Introduction
Experimental draft PR for playing with a type encoded matcher similar to irregex. Ideally this wouldn't necessarily need to be used directly, though it could, but would serve more as an IR for building a NFA state graph for optimizing.
# Linked Issues
#58 
# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
