### PR TITLE
Feat/51/break dependence on collections ext

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,4 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
 	"name": "Rust",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye"
-
-	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 workspace = ".."
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 
 [[bench]]
 name = "linear_scaling_of_input"

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -356,7 +356,7 @@ pub fn compile_many(regex_asts: Vec<ast::Regex>) -> Result<Instructions, String>
     Ok(Instructions::new(sets, opcodes))
 }
 
-/// from a stack of offsets, starting from last expression start first,
+/// From a stack of offsets, starting from last expression start first,
 /// generate all `Split` operations to jump to the corresponding offsets.
 fn generate_nested_split_expressions(
     mut offset_stack: Vec<i32>,
@@ -366,23 +366,17 @@ fn generate_nested_split_expressions(
     let mut expr_splits = vec![];
 
     for offset in (1..split_cnt).rev() {
-        match offset {
-            offset if offset == 1 => {
-                // safe to while loop condition asserting 2 elements are present.
-                let primary_start = offset_stack.pop().unwrap() + offset;
-                let secondary_start = offset_stack.pop().unwrap() + offset;
-                expr_splits.push(RelativeOpcode::Split(primary_start, secondary_start));
-            }
-            offset if offset > 1 => {
-                // safe to while loop condition due to guarantee there is atleast 1 element in the queue.
-                let primary_start = offset_stack.pop().unwrap() + offset;
+        if offset == 1 {
+            // safe to while loop condition asserting 2 elements are present.
+            let primary_start = offset_stack.pop().unwrap() + offset;
+            let secondary_start = offset_stack.pop().unwrap() + offset;
+            expr_splits.push(RelativeOpcode::Split(primary_start, secondary_start));
+        } else {
+            // safe to while loop condition due to guarantee there is atleast 1 element in the queue.
+            let primary_start = offset_stack.pop().unwrap() + offset;
 
-                // jump to the next expr, with the secondary branch going to the next split
-                expr_splits.push(RelativeOpcode::Split(primary_start, 1));
-            }
-
-            // this case should never be encountered due to loop guarantee.
-            _ => unreachable!(),
+            // jump to the next expr, with the secondary branch going to the next split
+            expr_splits.push(RelativeOpcode::Split(primary_start, 1));
         }
     }
 

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -42,10 +42,6 @@
 //! )
 //! ```
 
-#![warn(clippy::cast_lossless)]
-#![warn(clippy::cast_possible_truncation)]
-#![warn(clippy::cast_possible_wrap)]
-
 pub mod ast;
 pub mod bytecode;
 pub mod compiler;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 workspace = ".."
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 
 [[bench]]
 name = "linear_scaling_of_input"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,5 +19,4 @@ path = "benches/deserialization.rs"
 harness = false
 
 [dependencies]
-collections-ext = { git = "https://github.com/ncatelli/collections-ext", branch = "main" }
 unicode-categories = { git = "https://github.com/ncatelli/unicode-categories", tag = "v0.2.0" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,11 +34,11 @@
 //! }
 //! ```
 
-use collections_ext::set::sparse::SparseSet;
 use std::fmt::{Debug, Display};
 
 pub mod bytecode;
 pub use bytecode::from_binary;
+mod sparse_set;
 
 /// Represents a defined match group for a pattern.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -196,13 +196,13 @@ impl<const SG: usize> Thread<SG> {
 /// Stores all active threads and a set representing the evaluation generation.
 #[derive(Debug)]
 struct Threads<const SG: usize> {
-    gen: SparseSet,
+    gen: sparse_set::SparseSet,
     threads: Vec<Thread<SG>>,
 }
 
 impl<const SG: usize> Threads<SG> {
     pub fn with_set_size(set_capacity: usize) -> Self {
-        let ops = SparseSet::new(set_capacity);
+        let ops = sparse_set::SparseSet::new(set_capacity);
         Self {
             threads: vec![],
             gen: ops,
@@ -212,7 +212,7 @@ impl<const SG: usize> Threads<SG> {
 
 impl<const SG: usize> Default for Threads<SG> {
     fn default() -> Self {
-        let ops = SparseSet::new(0);
+        let ops = sparse_set::SparseSet::new(0);
         Self {
             threads: vec![],
             gen: ops,

--- a/runtime/src/sparse_set.rs
+++ b/runtime/src/sparse_set.rs
@@ -1,0 +1,186 @@
+//! Provides an implementation of a SparseSet as an alternative to HashSets.
+
+extern crate alloc;
+use alloc::{vec, vec::Vec};
+
+pub struct SparseSet {
+    elems: usize,
+    dense: Vec<Option<usize>>,
+    sparse: Vec<usize>,
+}
+
+impl SparseSet {
+    /// Initializes a new set of taking a value representing the maximum size
+    /// of the set.
+    #[must_use]
+    pub fn new(max_len: usize) -> Self {
+        Self {
+            elems: 0,
+            // initialize 0th index to non-zero so it doesn't match as a set
+            // member by default.
+            dense: vec![],
+            sparse: vec![0; max_len],
+        }
+    }
+
+    /// Returns the number of elements that the set can hold without reallocating.
+    #[allow(unused)]
+    pub fn capacity(&self) -> usize {
+        self.sparse.capacity()
+    }
+
+    /// Returns the number of elements in the set.
+    #[allow(unused)]
+    pub fn len(&self) -> usize {
+        self.elems
+    }
+
+    /// Inserts a value into the set.
+    pub fn insert(&mut self, val: usize) {
+        if self.contains(&val) {
+            return;
+        }
+
+        if self.sparse.capacity() <= val {
+            // double the size.
+            self.resize(val * 2)
+        }
+
+        // # Safety
+        //
+        // Above capacity check guarantees the set is atleast large enough to
+        // insert the value.
+        unsafe { self.insert_unchecked(val) };
+    }
+
+    /// Inserts a value into the set.
+    ///
+    /// This is the unchecked alternative to `insert`.
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function are responsible that these preconditions are
+    /// satisfied:
+    ///
+    /// * The value must not exceed the max length of the set;
+    ///
+    /// Failing that will cause a panic.
+    pub unsafe fn insert_unchecked(&mut self, val: usize) {
+        let dense_len = self.dense.len();
+        let sparse_idx = self.sparse[val];
+        if dense_len > sparse_idx && self.dense[sparse_idx].is_none() {
+            self.dense[sparse_idx] = Some(val)
+        } else {
+            self.dense.push(Some(val));
+            self.sparse[val] = dense_len;
+        }
+
+        self.elems += 1
+    }
+
+    /// Returns `true` if the set contains a value.
+    pub fn contains(&self, val: &usize) -> bool {
+        self.sparse
+            .get(*val)
+            .map(|&dense_idx| self.dense.get(dense_idx) == Some(&Some(*val)))
+            // if none, the bounds of the set are exceeded and thus doesn't
+            // contain the value.
+            .unwrap_or(false)
+    }
+
+    #[allow(unused)]
+    pub fn remove(&mut self, val: &usize) -> bool {
+        if self.contains(val) {
+            // safety guaranteed by above contains check
+            unsafe { self.remove_unchecked(val) };
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes a value into the set.
+    ///
+    /// This is the unchecked alternative to `remove`.
+    ///
+    /// # Safety
+    ///
+    /// Callers of this function are responsible that these preconditions are
+    /// satisfied:
+    ///
+    /// * The value must not exceed the max length of the set;
+    /// * The value must be defined in the set.
+    ///
+    /// Failing that will cause a panic.
+    unsafe fn remove_unchecked(&mut self, val: &usize) {
+        let dense_idx = self.sparse[*val];
+        self.dense[dense_idx] = None;
+        self.elems -= 1;
+    }
+
+    /// Clears the set, removing all values.
+    pub fn clear(&mut self) {
+        self.elems = 0;
+        self.dense.clear();
+    }
+
+    fn resize(&mut self, new_len: usize) {
+        self.sparse.resize_with(new_len, || 0)
+    }
+}
+
+impl core::fmt::Debug for SparseSet {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SparseSet({:?}", &self.dense)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_cause_resize_on_insert_with_bound_exceed() {
+        let mut set = SparseSet::new(0);
+
+        // set capacity is equivalent to provided max_len.
+        assert!(set.capacity() == 0);
+
+        set.insert(10);
+
+        // after insert capacity is 2x largest insert value.
+        assert!(set.capacity() == 20);
+    }
+
+    #[test]
+    fn should_clear_value_on_delete() {
+        let mut set = SparseSet::new(0);
+
+        set.insert(1);
+        assert!(set.contains(&1));
+        assert_eq!(1, set.len());
+
+        set.remove(&1);
+        assert!(!set.contains(&1));
+        assert_eq!(0, set.len());
+    }
+
+    #[test]
+    fn should_reuse_slots_on_delete() {
+        let mut set = SparseSet::new(0);
+
+        set.insert(1);
+        assert!(set.contains(&1));
+        assert_eq!(1, set.len());
+
+        // assert value was cleared from set
+        set.remove(&1);
+        assert!(!set.contains(&1));
+        assert!(set.dense.len() == 1 && set.dense[0].is_none());
+
+        // Re-add the previous value and assert slot is reused.
+        set.insert(1);
+        assert!(set.contains(&1));
+        assert!(set.dense.len() == 1 && set.dense[0] == Some(1));
+    }
+}


### PR DESCRIPTION
# Introduction
Prepatory work to setup for implementing a state graph. This cleans up clippy lints and removes external deps that are not pinned to a tag.
# Linked Issues
#51 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
